### PR TITLE
Ce genre de parsing xml pour events ETW

### DIFF
--- a/samples/event_log/wevtutil.py
+++ b/samples/event_log/wevtutil.py
@@ -340,7 +340,7 @@ def format_opcode_metadata(publisher_metadata, opcode_metadata, args):
         #"      opcode: {opcode.task_value:d}",  # TODO
         "    message: {opcode_message:s}", 
     ]).format(
-        level=opcode_metadata, 
+        opcode=opcode_metadata, 
         opcode_message=get_message(publisher_metadata, opcode_metadata.message_id, args.gm)
     )
 

--- a/samples/event_log/wevtutil.py
+++ b/samples/event_log/wevtutil.py
@@ -387,16 +387,16 @@ def format_event_metadata(publisher_metadata, event_metadata, args):
     )
 
 def enum_publishers(args):
-
+    """ enum-publishers verb implementation """
     manager = event_log.EvtlogManager()
     for publisher in sorted(list(manager.publishers), key=lambda pub:pub.name.lower()):    
         print(publisher.name)        
 
 def get_publisher(args):
+    """ get-publisher verb implementation """
     
     manager = event_log.EvtlogManager()
     publisher = manager.open_publisher(args.publisher_name)
-
 
     channels_info = "\n".join(map(lambda c: format_channel_metadata(publisher.metadata, c, args), publisher.metadata.channels_metadata))
     levels_info = "\n".join(map(lambda l: format_level_metadata(publisher.metadata, l, args), publisher.metadata.levels_metadata))
@@ -493,6 +493,7 @@ if __name__ == '__main__':
 
     import argparse
     parser = argparse.ArgumentParser("wevtutil script reimplementation using PythonForWindows")
+    parser.add_argument("-v", "--verbose", action="store_true", help="active verbose logging")
     action_parsers = parser.add_subparsers(dest="action", help="subparsers for action specific arguments")
 
     # we can't express shorthands easily like ep for enum-publishers since only Python3's argparse surpport parser "aliases"
@@ -516,6 +517,12 @@ if __name__ == '__main__':
 
 
     args = parser.parse_args()
+
+    if args.verbose:
+        logging.basicConfig(level=logging.DEBUG)
+    else:
+        logging.basicConfig(level=logging.INFO)
+
     main(args)
 
 

--- a/samples/event_log/wevtutil.py
+++ b/samples/event_log/wevtutil.py
@@ -1,0 +1,220 @@
+import os
+import sys
+import ctypes
+
+import windows
+import windows.generated_def as gdef
+from windows.winobject import event_log
+
+
+def get_message(publisher_metadata, message_id, get_str_message):
+    """ if --gm is set, try to return the str message associated. If not, return the raw value id """
+    if not get_str_message:
+        return "%d" % message_id
+
+    try:
+        return publisher_metadata.message(message_id)
+    except WindowsError as e:
+        if e.winerror != gdef.ERROR_INVALID_PARAMETER:
+            raise
+        return ""
+
+def format_channel_metadata(publisher_metadata, channel_metadata, args):
+    """ Str formating channel metadata """
+    return "\n".join([
+        "  channel:",
+        "    name: {channel.name:s}",
+        "    id: {channel.id:d}",
+        "    flags: {channel.flags:d}",
+        "    message: {channel_message:s}",
+    ]).format(
+        channel=channel_metadata, 
+        channel_message=get_message(publisher_metadata, channel_metadata.message_id, args.gm)
+    )
+
+def format_level_metadata(publisher_metadata, level_metadata, args):
+    """ Str formating level metadata """
+    return "\n".join([
+        "  level:",
+        "    name: {level.name:s}",
+        "    value: {level.value:d}",
+        "    message: {level_message:s}", 
+    ]).format(
+        level=level_metadata, 
+        level_message=get_message(publisher_metadata, level_metadata.message_id, args.gm)
+    )
+
+def format_opcode_metadata(publisher_metadata, opcode_metadata, args):
+    """ Str formating opcode metadata """
+    return "\n".join([
+        "  opcode:",
+        "    name: {opcode.name:s}",
+        "    value: {opcode.value:d}",
+        #"      task: {opcode.task:d}",          # TODO
+        #"      opcode: {opcode.task_value:d}",  # TODO
+        "    message: {opcode_message:s}", 
+    ]).format(
+        level=opcode_metadata, 
+        opcode_message=get_message(publisher_metadata, opcode_metadata.message_id, args.gm)
+    )
+
+def format_task_metadata(publisher_metadata, task_metadata, args):
+    """ Str formating task metadata """
+    return "\n".join([
+        "  task:",
+        "    name: {task.name:s}",
+        "    value: {task.value:d}",
+        "    eventGUID: {task.event_guid:s}",   
+        "    message: {task_message:s}",        
+    ]).format(
+        task=task_metadata, 
+        task_message=get_message(publisher_metadata, task_metadata.message_id, args.gm)
+    )
+
+def format_keyword_metadata(publisher_metadata, keyword_metadata, args):
+    """ Str formating keyword metadata """
+    return "\n".join([
+        "  keyword:",
+        "    name: {keyword.name:s}",
+        "    mask: {keyword.value:x}",
+        "    message: {keyword_message:s}",  
+    ]).format(
+        keyword=keyword_metadata, 
+        keyword_message=get_message(publisher_metadata, keyword_metadata.message_id, args.gm)
+    )
+
+def format_event_metadata(publisher_metadata, event_metadata, args):
+    """ Str formating keyword metadata """
+    return "\n".join([
+         "  event:",
+        "    value: {event.id:d}",
+        "    version: {event.version:d}",
+        "    opcode: {event.opcode:d}",
+        "    channel: {event.channel_id:d}",
+        "    level: {event.level:d}",
+        "    task: {event.task:d}",
+        "    keywords: 0x{event.keyword:016x}",
+        "    message: {event_message:s}" 
+    ]).format(
+        event=event_metadata, 
+        event_message=get_message(publisher_metadata, event_metadata.message_id, args.gm)
+    )
+
+def enum_publishers(args):
+
+    manager = event_log.EvtlogManager()
+    for publisher in sorted(list(manager.publishers), key=lambda pub:pub.name.lower()):    
+        print(publisher.name)        
+
+def get_publisher(args):
+    
+    manager = event_log.EvtlogManager()
+    publisher = manager.open_publisher(args.publisher_name)
+
+
+    channels_info = "\n".join(map(lambda c: format_channel_metadata(publisher.metadata, c, args), publisher.metadata.channels_metadata))
+    levels_info = "\n".join(map(lambda l: format_level_metadata(publisher.metadata, l, args), publisher.metadata.levels_metadata))
+    opcodes_info = "\n".join(map(lambda o: format_opcode_metadata(publisher.metadata, o, args), publisher.metadata.opcodes_metadata))
+    tasks_info = "\n".join(map(lambda t: format_task_metadata(publisher.metadata, t, args), publisher.metadata.tasks_metadata))
+    keywords_info = "\n".join(map(lambda k: format_keyword_metadata(publisher.metadata, k, args), publisher.metadata.keywords_metadata))
+    events_info = "\n".join(map(lambda e: format_event_metadata(publisher.metadata, e, args), publisher.metadata.events_metadata))
+
+    publisher_infos = "\n".join([
+        "name: {pub_name:s}",
+        "guid: {pub_guid:s}",
+    ]).format(
+        pub_name=publisher.name,
+        pub_guid=publisher.metadata.guid.to_string(),
+    )
+
+    if publisher.metadata.message_resource_filepath != None:
+        publisher_infos += "\n"
+        publisher_infos += "resourceFileName: {:s}".format(publisher.metadata.message_resource_filepath)
+    if publisher.metadata.message_parameter_filepath != None:
+        publisher_infos += "\n"
+        publisher_infos += "parameterFileName: {:s}".format(publisher.metadata.message_parameter_filepath)
+    if publisher.metadata.message_filepath != None:
+        publisher_infos += "\n"
+        publisher_infos += "messageFileName: {:s}".format(publisher.metadata.message_filepath)
+
+    publisher_infos += "\n"
+    publisher_infos += "message: {:s}".format(get_message(publisher.metadata, publisher.metadata.message_id, args.gm))
+
+    # Channels
+    publisher_infos += "\n"
+    publisher_infos += "channels:"
+    if channels_info != "":
+        publisher_infos += "\n"
+        publisher_infos += channels_info
+
+    # Levels
+    publisher_infos += "\n"
+    publisher_infos += "levels:"
+    if levels_info != "":
+        publisher_infos += "\n"
+        publisher_infos += levels_info
+
+    # Opcodes
+    publisher_infos += "\n"
+    publisher_infos += "opcodes:"
+    if opcodes_info != "":
+        publisher_infos += "\n"
+        publisher_infos += opcodes_info
+
+    # Tasks
+    publisher_infos += "\n"
+    publisher_infos += "tasks:"
+    if tasks_info != "":
+        publisher_infos += "\n"
+        publisher_infos += tasks_info
+
+    # Keywords
+    publisher_infos += "\n"
+    publisher_infos += "keywords:"
+    if keywords_info != "":
+        publisher_infos += "\n"
+        publisher_infos += keywords_info
+
+    # Events
+    if args.ge:
+        publisher_infos += "\n"
+        publisher_infos += "events:"
+        if events_info != "":
+            publisher_infos += "\n"
+            publisher_infos += events_info
+
+    print(publisher_infos)
+
+    
+
+def main(args):
+
+    if args.action == "enum-publishers":
+        enum_publishers(args)
+
+    elif args.action == "get-publisher":
+        get_publisher(args)
+    else:
+        raise NotImplementedError("Unknown action : %s" % args.action)
+
+if __name__ == '__main__':
+
+    import argparse
+    parser = argparse.ArgumentParser("wevtutil script reimplementation using PythonForWindows")
+    action_parsers = parser.add_subparsers(dest="action", help="subparsers for action specific arguments")
+
+    # we can't express shorthands easily like ep for enum-publishers since only Python3's argparse surpport parser "aliases"
+    enum_publishers_parser = action_parsers.add_parser("enum-publishers", help="enum-publishers verb")
+    
+    get_publisher_parser = action_parsers.add_parser("get-publisher", help="get-publisher verb")
+    get_publisher_parser.add_argument("publisher_name", type=str, help="registered publisher name")
+    get_publisher_parser.add_argument("--ge", action="store_true", help="get event metadata")
+    get_publisher_parser.add_argument("--gm", action="store_true", help="get message name instead of raw id")
+    # get_publisher_parser.add_argument("--f", type=str, help="format")                                           # TODO
+    # get_publisher_parser.add_argument("--im", "--install-manifest", type=str, help="install manifest ???")      # TODO
+
+
+    args = parser.parse_args()
+    main(args)
+
+

--- a/samples/event_log/wevtutil.py
+++ b/samples/event_log/wevtutil.py
@@ -158,16 +158,26 @@ class RealtimeEventLogger(RealtimeEventLoggerBase):
             value = self.parse_unicode_string(stream)
         elif in_type == "win:UInt8":
             value = struct.unpack("B", stream.read(1))[0]
+
+        elif in_type == "win:Int32":
+            value = struct.unpack("I", stream.read(4))[0]
         elif in_type == "win:UInt32":
             value = struct.unpack("I", stream.read(4))[0]
         elif in_type == "win:HexInt32":
             value = struct.unpack("I", stream.read(4))[0]
         elif in_type == "xs:unsignedLong":
             value = struct.unpack("I", stream.read(4))[0]
+
         elif in_type == "win:UInt64":
             value = struct.unpack("Q", stream.read(8))[0]
         elif in_type == "win:Pointer":
             value = struct.unpack("Q", stream.read(8))[0]
+        elif in_type == "win:Double":
+            value = struct.unpack("Q", stream.read(8))[0]
+
+        elif in_type == "win:Boolean":
+            value = struct.unpack("I", stream.read(4))[0] == 1
+
         elif in_type == "win:Binary":
             if not length:
                 raise ValueError(" param_in_type (%s) cannot be used with a null length value" % in_type)
@@ -175,6 +185,7 @@ class RealtimeEventLogger(RealtimeEventLoggerBase):
             # TODO : we should return the raw bytes buffer, since get_param_str_format is too crude 
             #        to properly display win:SocketAddress parameters
             value = binascii.hexlify(stream.read(length)) 
+
         elif in_type == "win:GUID":
             guid_data = struct.unpack("IHHBBBBBBBB", stream.read(16))
             value = gdef.GUID.from_raw(*guid_data).to_string()
@@ -185,7 +196,10 @@ class RealtimeEventLogger(RealtimeEventLoggerBase):
 
     def get_param_str_format(self, param_out_type):
         PYTHON_FORMAT_DICT = {
+            "xs:boolean" : "s", # "True" or "False"
             "xs:unsignedByte" : "02x",
+            "xs:int" : "d",
+            "xs:double" : "f",
             "xs:unsignedInt" : "d",
             "xs:unsignedLong" : "d",
             "win:ErrorCode"  : "x",

--- a/samples/event_log/wevtutil.py
+++ b/samples/event_log/wevtutil.py
@@ -1,10 +1,296 @@
 import os
+import re
 import sys
+import xml
 import ctypes
+import struct
+import pickle
+import logging
+import binascii
 
+from io import BytesIO
+from collections import namedtuple
+
+# PythonForWindows
 import windows
 import windows.generated_def as gdef
 from windows.winobject import event_log
+
+""" ParsedElement : This represent a deserialized element for the EventRecord user data, using the xml template associated with the event. """
+ParsedElement = namedtuple('ParsedElement', 'index, name, value, format')
+
+class RealtimeEventLoggerBase(object):
+    """ Virtual class, used mainly to inject the instance in the EventRecord's context """
+
+    def __init__(self):
+        self.etw_trace = None
+
+    def start_process_trace(self):
+        """ """
+
+        # Blocking call here, you can't do anything anymore except killing the trace
+        self.etw_trace.process(RealtimeEventLogger.callback, context = self)
+
+    @staticmethod
+    def callback(event):
+        """ Custom callback for listening to ETW events and process them. """
+        self = event.context
+        self.process_event(event)
+
+
+    def process_event(self, event):
+        raise NotImplementedError("You should implement this method in a subclass !")
+
+
+
+class RealtimeEventLogger(RealtimeEventLoggerBase):
+    """ Custom reimplementation of a event logger. """
+
+    def __init__(self, trace_name, publisher = None):
+        super(RealtimeEventLogger, self).__init__()
+
+        # Open ETW publisher
+        self.publisher = None
+        self.publisher_name = publisher
+        self.publisher_guid = None
+
+        if self.publisher_name:
+            manager = event_log.EvtlogManager()
+            self.publisher = manager.open_publisher(self.publisher_name)
+            self.publisher_guid = self.publisher.metadata.guid
+            logging.debug("publisher guid : %s" % self.publisher_guid.to_string())
+
+        # ETW trace
+        self.any_keywords = 0
+        self.etw_trace_name = trace_name
+
+    def setup_trace(self):
+
+        # Collecting all keywords for listening to events to
+        event_keywords = set(map(lambda event_metadata: event_metadata.keyword, self.publisher.metadata.events_metadata))
+        self.any_keywords = 0x00
+        for keyword in list(event_keywords):
+            self.any_keywords |= keyword
+
+        logging.debug("events KeywordsAny : 0x%x" % self.any_keywords)
+       
+
+        # Create a custom realtime ETW trace for printing out events
+        self.etw_trace = windows.system.etw.open_trace(self.etw_trace_name)
+
+
+    def start_trace(self):
+
+        self.etw_trace.start()
+
+        # We can't configure etw trace if it's not started previously
+        self.etw_trace.enable_ex(
+            self.publisher_guid.to_string(), 
+            flags=0, 
+            level=0xff, 
+            any_keyword=self.any_keywords
+        )
+
+        self.start_process_trace()
+
+    def stop_trace(self):
+        # No way to stop it from python :(
+        os.system("logman -ets stop %s" %  self.etw_trace_name)
+
+    def process_event(self, event):
+        """ Custom callback for listening to ETW events and parse them correctly. """
+
+        try:
+            if event.guid == self.publisher.metadata.guid:
+
+                # Check this is an event we can parse
+                event_metadata = self.lookup_event_metadata(self.publisher, event.id)
+                if not event_metadata:
+                    return
+
+                logging.debug("recv event user data: %s" % event.user_data)
+                logging.debug("recv xml template : %s" % event_metadata.template)
+
+                # Deserialize event.user_data based on the event_metadata xml template
+                message_data = event.user_data
+                message_params = self.parse_user_data(event_metadata.template, message_data)
+
+                logging.debug("message params : %s" %  message_params)
+
+                # "sprintf" the message using the event format message as well as the deserialized elements
+                template_message = self.publisher.metadata.message(event_metadata.message_id)
+                event_message = self.format_event_log_message(template_message, message_params)
+                
+                print(event_message)
+
+        except Exception as unke:
+            print("Unhandled exception in Evtlogger.process_event : %s" % unke)
+            sys.exit(0)  # Exiting on unknown error, since this is the only way to have some control
+        finally:
+            pass
+
+    def parse_unicode_string(self, stream):
+        """ Deserialize a wide string """
+
+        uni_string = b""
+        while True:
+            unicode_byte = stream.read(2)
+
+            if unicode_byte == b"\x00\x00":
+                break
+
+            uni_string += unicode_byte
+
+        return uni_string.decode("utf-16")
+
+    def parse_element(self, in_type, stream, length = None):
+
+        # Types definis dans les templates
+        # https://docs.microsoft.com/en-us/windows/win32/wes/eventmanifestschema-inputtype-complextype
+        if in_type == "win:UnicodeString":
+            value = self.parse_unicode_string(stream)
+        elif in_type == "win:UInt8":
+            value = struct.unpack("B", stream.read(1))[0]
+        elif in_type == "win:UInt32":
+            value = struct.unpack("I", stream.read(4))[0]
+        elif in_type == "win:HexInt32":
+            value = struct.unpack("I", stream.read(4))[0]
+        elif in_type == "xs:unsignedLong":
+            value = struct.unpack("I", stream.read(4))[0]
+        elif in_type == "win:UInt64":
+            value = struct.unpack("Q", stream.read(8))[0]
+        elif in_type == "win:Pointer":
+            value = struct.unpack("Q", stream.read(8))[0]
+        elif in_type == "win:Binary":
+            if not length:
+                raise ValueError(" param_in_type (%s) cannot be used with a null length value" % in_type)
+            
+            # TODO : we should return the raw bytes buffer, since get_param_str_format is too crude 
+            #        to properly display win:SocketAddress parameters
+            value = binascii.hexlify(stream.read(length)) 
+        elif in_type == "win:GUID":
+            guid_data = struct.unpack("IHHBBBBBBBB", stream.read(16))
+            value = gdef.GUID.from_raw(*guid_data).to_string()
+        else:
+            raise ValueError("unrecognized param_in_type : %s" % in_type)
+
+        return value
+
+    def get_param_str_format(self, param_out_type):
+        PYTHON_FORMAT_DICT = {
+            "xs:unsignedByte" : "02x",
+            "xs:unsignedInt" : "d",
+            "xs:unsignedLong" : "d",
+            "win:ErrorCode"  : "x",
+            "win:HexInt64"   : "0x08x",
+            "win:HexInt32"   : "0x04x",
+            "xs:string"      : "s",
+            "win:SocketAddress" : "s" # TODO
+        }
+
+        if param_out_type not in PYTHON_FORMAT_DICT:
+            raise ValueError("unrecognized out param : %s" %  param_out_type)
+
+        return PYTHON_FORMAT_DICT[param_out_type]
+
+    def parse_user_data(self, template, data):
+        """ 
+        Deserialize event.user_data based on the associated publisher's template.
+        Return a list of ParsedElement(Name:string, Value:py_object, Type:py_type).
+        """
+            
+        # xml.dom.minidom.parseString raise an error on parseString() if the xml template is empty
+        if not len(template):
+            return []
+
+        stream = BytesIO(data)
+        xmltemplate = xml.dom.minidom.parseString(template)
+        
+        params = []
+        context = {} # saving parsed items for "count" elements
+
+        # xmltemplate.getElementsByTagName("data") return data node within <struct> decl, so we can't use it
+        direct_data_nodes = filter(lambda n: n.nodeType == 1 and n.tagName == "data", xmltemplate.childNodes[0].childNodes)
+
+        for (i,param_data) in enumerate(direct_data_nodes):
+
+            param_name = param_data.attributes["name"].value
+            param_in_type = param_data.attributes["inType"].value
+            param_out_type = param_data.attributes["outType"].value
+
+            # Some param are repeating, and "count" refers to the variable holding the number of repetitions
+            param_count = param_data.attributes.get("count", None)
+            if param_count != None:
+                param_count = context[param_count.value] # must be already set
+
+            # Some param (win:Binary) have a length attribute
+            param_length = param_data.attributes.get("length", None)
+            if param_length != None:
+                param_length = context[param_length.value] # must be already set
+            
+
+            # Parse element
+            if param_count != None:
+
+                # ignoring element with value count of 0
+                if param_count == 0:
+                    continue
+
+                value = [ self.parse_element(param_in_type, stream, param_length) for c in range(param_count) ]
+            else:
+                value = self.parse_element(param_in_type, stream, param_length)
+
+            # Get python string formating 
+            format_type = self.get_param_str_format(param_out_type)
+
+            context[param_name] = value
+
+            logging.debug(ParsedElement(i, param_name,value, format_type))
+            params.append(ParsedElement(i, param_name,value, format_type))
+
+        return params
+
+    def lookup_event_metadata(self, publisher, event_id):
+        matching_events_metadata = list(filter(lambda event_meta: event_meta.id == event_id, publisher.metadata.events_metadata))
+        
+        if not len(matching_events_metadata):
+            return None
+
+        if len(matching_events_metadata) > 1:
+            return None
+
+        return matching_events_metadata[0]
+
+    def format_event_log_message(self, template, event_args):
+        
+        py_template = ""
+        last_span = (0,0)
+        
+        # Convert message template to python string formating
+        # e.g. : "ParseError: HResult: %1, Error: %2." into "ParseError: HResult: {arg0:x}, Error: {arg1:d}."
+        pattern = re.compile(r"%(\d)")
+        for match in re.finditer(pattern, template):
+        
+            arg_id = int(match.groups()[0]) - 1 # event's template message index params from 1 to N, wtf
+            span = match.span()
+            str_format = ""
+        
+            str_format = "{a%d:%s}" % (arg_id, event_args[arg_id].format)
+        
+            py_template += template[last_span[1]:span[0]] + str_format
+            last_span = span
+        
+        py_template += template[last_span[1]:]
+        
+        logging.debug(py_template)
+        
+        # string formating using Python .format()
+        events_kwargs =  {"a%d" % (x.index) : x.value for x in event_args}
+        logging.debug(events_kwargs)
+        message = py_template.format(**events_kwargs)
+        logging.debug(message)
+        return message
+
 
 
 def get_message(publisher_metadata, message_id, get_str_message):
@@ -183,17 +469,23 @@ def get_publisher(args):
             publisher_infos += "\n"
             publisher_infos += events_info
 
+    publisher_infos += "\n"
     print(publisher_infos)
-
     
 
 def main(args):
 
     if args.action == "enum-publishers":
         enum_publishers(args)
-
     elif args.action == "get-publisher":
         get_publisher(args)
+    elif args.action == "start-trace":
+        evl = RealtimeEventLogger(args.etw_name, publisher = args.publisher_name)
+        evl.setup_trace()
+        evl.start_trace()
+    elif args.action == "stop-trace":
+        evl = RealtimeEventLogger(args.etw_name)
+        evl.stop_trace()
     else:
         raise NotImplementedError("Unknown action : %s" % args.action)
 
@@ -212,6 +504,15 @@ if __name__ == '__main__':
     get_publisher_parser.add_argument("--gm", action="store_true", help="get message name instead of raw id")
     # get_publisher_parser.add_argument("--f", type=str, help="format")                                           # TODO
     # get_publisher_parser.add_argument("--im", "--install-manifest", type=str, help="install manifest ???")      # TODO
+
+
+    # Not a wevutil command, but something nice to have ;p
+    start_trace_parser = action_parsers.add_parser("start-trace", help="start a realtime ETW trace")
+    start_trace_parser.add_argument("etw_name", type=str, help="ETW trace name")
+    start_trace_parser.add_argument("publisher_name", type=str, help="registered publisher name")
+
+    stop_trace_parser = action_parsers.add_parser("stop-trace", help="start a realtime ETW trace")
+    stop_trace_parser.add_argument("etw_name", type=str, help="ETW trace name")
 
 
     args = parser.parse_args()

--- a/samples/event_log/wevtutil.py
+++ b/samples/event_log/wevtutil.py
@@ -114,11 +114,18 @@ class RealtimeEventLogger(RealtimeEventLoggerBase):
                 # Deserialize event.user_data based on the event_metadata xml template
                 message_data = event.user_data
                 message_params = self.parse_user_data(event_metadata.template, message_data)
-
                 logging.debug("message params : %s" %  message_params)
 
+
+                try:
+                    template_message = self.publisher.metadata.message(event_metadata.message_id)
+                    logging.debug("template_message : %s" %  message_params)
+                except WindowsError as e:
+                    if e.winerror != gdef.ERROR_INVALID_PARAMETER:
+                        raise
+                    return
+
                 # "sprintf" the message using the event format message as well as the deserialized elements
-                template_message = self.publisher.metadata.message(event_metadata.message_id)
                 event_message = self.format_event_log_message(template_message, message_params)
                 
                 print(event_message)

--- a/windows/winobject/event_log.py
+++ b/windows/winobject/event_log.py
@@ -479,6 +479,14 @@ class PublisherMetadata(EvtHandle):
         return cls(winproxy.EvtOpenPublisherMetadata(None, name, None, 0, 0), name)
 
     @property
+    def guid(self):
+        """The GUID associated with this provider
+
+        :type:  [:class:`GUID`] -- the GUID in a XXXXXXXXXX-YYYY-ZZZZ-TTTT-VVVVVVVVVV form
+        """
+        return publishinfo(self, gdef.EvtPublisherMetadataPublisherGuid).value
+
+    @property
     def chanrefs(self):
         """Identifies the channels child element of the provider.
 
@@ -550,12 +558,16 @@ class PublisherMetadata(EvtHandle):
         return sbuff.value
 
     @property
-    def guid(self):
-        """The GUID associated with this provider
-
-        :type:  [:class:`GUID`] -- the GUID in a XXXXXXXXXX-YYYY-ZZZZ-TTTT-VVVVVVVVVV form
+    def message_name(self):
         """
-        return publishinfo(self, gdef.EvtPublisherMetadataPublisherGuid).value
+        """
+        return self.message(publishinfo(self, gdef.EvtPublisherMetadataPublisherMessageID).value)
+
+    @property
+    def message_filepath(self):
+        """
+        """
+        return publishinfo(self, gdef.EvtPublisherMetadataMessageFilePath).value
 
 
     def __repr__(self):

--- a/windows/winobject/event_log.py
+++ b/windows/winobject/event_log.py
@@ -720,10 +720,10 @@ class PublisherMetadata(EvtHandle):
         return sbuff.value
 
     @property
-    def message_name(self):
+    def message_id(self):
         """
         """
-        return self.message(publishinfo(self, gdef.EvtPublisherMetadataPublisherMessageID).value)
+        return publishinfo(self, gdef.EvtPublisherMetadataPublisherMessageID).value
 
     @property
     def message_filepath(self):

--- a/windows/winobject/event_log.py
+++ b/windows/winobject/event_log.py
@@ -450,6 +450,10 @@ class PublisherMetadataChannel(object):
     def index(self):
         return int(self._query_channel_metadata_property(gdef.EvtPublisherMetadataChannelReferenceIndex))
 
+    @property
+    def message_id(self):
+        return int(self._query_channel_metadata_property(gdef.EvtPublisherMetadataChannelReferenceMessageID))
+
 
 class PublisherMetadataLevel(object):
 

--- a/windows/winobject/event_log.py
+++ b/windows/winobject/event_log.py
@@ -416,6 +416,7 @@ class ChannelConfig(EvtHandle):
     def enabled(self):
         return bool(chaninfo(self, gdef.EvtChannelConfigEnabled).value)
 
+
     @property
     def classic(self):
         """``True`` if the channel is a classic event channel (for example the Application or System log)"""

--- a/windows/winobject/event_log.py
+++ b/windows/winobject/event_log.py
@@ -409,6 +409,10 @@ class ChannelConfig(EvtHandle):
         return [EvtPublisher(pub) for pub in chaninfo(self, gdef.EvtChannelPublisherList).value]
 
     @property
+    def keywords(self):
+        return int(chaninfo(self, gdef.EvtChannelPublishingConfigKeywords).value)
+
+    @property
     def enabled(self):
         return bool(chaninfo(self, gdef.EvtChannelConfigEnabled).value)
 
@@ -510,6 +514,15 @@ class PublisherMetadata(EvtHandle):
             if e.winerror != gdef.ERROR_EVT_UNRESOLVED_VALUE_INSERT:
                 raise
         return sbuff.value
+
+    @property
+    def guid(self):
+        """The GUID associated with this provider
+
+        :type:  [:class:`GUID`] -- the GUID in a XXXXXXXXXX-YYYY-ZZZZ-TTTT-VVVVVVVVVV form
+        """
+        return publishinfo(self, gdef.EvtPublisherMetadataPublisherGuid).value
+
 
     def __repr__(self):
         return '<{0} "{1}">'.format(type(self).__name__, self.name)

--- a/windows/winobject/event_log.py
+++ b/windows/winobject/event_log.py
@@ -424,6 +424,31 @@ class ChannelConfig(EvtHandle):
     def __repr__(self):
         return '<{0} "{1}">'.format(type(self).__name__, self.name)
 
+class ChannelMetadata(object):
+
+    def __init__(self, pub_metada, channel_id):
+        super(ChannelMetadata, self).__init__()
+        self.pub_metada = pub_metada
+        self._id = channel_id
+
+    def _query_channel_metadata_property(self, propertyid):
+        return self.pub_metada.chanrefs.property(propertyid, self._id)
+
+    @property
+    def flags(self):
+        return int(self._query_channel_metadata_property(gdef.EvtPublisherMetadataChannelReferenceFlags))
+
+    @property
+    def name(self):
+        return str(self._query_channel_metadata_property(gdef.EvtPublisherMetadataChannelReferencePath))
+
+    @property
+    def id(self):
+        return int(self._query_channel_metadata_property(gdef.EvtPublisherMetadataChannelReferenceID))
+
+    @property
+    def index(self):
+        return int(self._query_channel_metadata_property(gdef.EvtPublisherMetadataChannelReferenceIndex))
 
 class EvtPublisher(object):
     """An Event provider"""
@@ -460,6 +485,15 @@ class PublisherMetadata(EvtHandle):
         :type: :class:`PropertyArray`
         """
         return PropertyArray(publishinfo(self, gdef.EvtPublisherMetadataChannelReferences).value)
+
+    @property
+    def channels_metadata(self):
+        """The :class:`ChannelMetadata` for each event this provider defines
+
+        :yield: :class:`ChannelMetadata`
+        """
+        return [ChannelMetadata(self, i) for i in range(self.chanrefs.size)]
+
 
     @property
     def events_metadata(self):

--- a/windows/winobject/event_log.py
+++ b/windows/winobject/event_log.py
@@ -781,8 +781,28 @@ class EventMetadata(EvtHandle):
 
     @property
     def channel_id(self):
-        """The the Channel attribute of the Event definition"""
+        """The Channel attribute of the Event definition"""
         return eventinfo(self, gdef.EventMetadataEventChannel).value
+
+    @property
+    def keyword(self):
+        """The keyword attribute of the Event definition"""
+        return eventinfo(self, gdef.EventMetadataEventKeyword).value
+
+    @property
+    def opcode(self):
+        """The opcode attribute of the Event definition"""
+        return eventinfo(self, gdef.EventMetadataEventOpcode).value
+
+    @property
+    def level(self):
+        """The level attribute of the Event definition"""
+        return eventinfo(self, gdef.EventMetadataEventLevel).value
+
+    @property
+    def task(self):
+        """The task attribute of the Event definition"""
+        return eventinfo(self, gdef.EventMetadataEventTask).value
 
     @property
     def message_id(self):

--- a/windows/winobject/event_log.py
+++ b/windows/winobject/event_log.py
@@ -424,15 +424,15 @@ class ChannelConfig(EvtHandle):
     def __repr__(self):
         return '<{0} "{1}">'.format(type(self).__name__, self.name)
 
-class ChannelMetadata(object):
+class PublisherMetadataChannel(object):
 
-    def __init__(self, pub_metada, channel_id):
-        super(ChannelMetadata, self).__init__()
-        self.pub_metada = pub_metada
+    def __init__(self, pub_metadata, channel_id):
+        super(PublisherMetadataChannel, self).__init__()
+        self.pub_metadata = pub_metadata
         self._id = channel_id
 
     def _query_channel_metadata_property(self, propertyid):
-        return self.pub_metada.chanrefs.property(propertyid, self._id)
+        return self.pub_metadata.chanrefs.property(propertyid, self._id)
 
     @property
     def flags(self):
@@ -449,6 +449,101 @@ class ChannelMetadata(object):
     @property
     def index(self):
         return int(self._query_channel_metadata_property(gdef.EvtPublisherMetadataChannelReferenceIndex))
+
+
+class PublisherMetadataLevel(object):
+
+    def __init__(self, pub_metadata, channel_id):
+        super(PublisherMetadataLevel, self).__init__()
+        self.pub_metadata = pub_metadata
+        self._id = channel_id
+
+    def _query_level_metadata_property(self, propertyid):
+        return self.pub_metadata.levelrefs.property(propertyid, self._id)
+
+    @property
+    def name(self):
+        return str(self._query_level_metadata_property(gdef.EvtPublisherMetadataLevelName))
+
+    @property
+    def value(self):
+        return int(self._query_level_metadata_property(gdef.EvtPublisherMetadataLevelValue))
+
+    @property
+    def message_id(self):
+        return int(self._query_level_metadata_property(gdef.EvtPublisherMetadataLevelMessageID))
+
+
+class PublisherMetadataOpcode(object):
+
+    def __init__(self, pub_metadata, channel_id):
+        super(PublisherMetadataOpcode, self).__init__()
+        self.pub_metadata = pub_metadata
+        self._id = channel_id
+
+    def _query_opcode_metadata_property(self, propertyid):
+        return self.pub_metadata.opcoderefs.property(propertyid, self._id)
+
+    @property
+    def name(self):
+        return str(self._query_opcode_metadata_property(gdef.EvtPublisherMetadataOpcodeName))
+
+    @property
+    def value(self):
+        return int(self._query_opcode_metadata_property(gdef.EvtPublisherMetadataOpcodeValue))
+
+    @property
+    def message_id(self):
+        return int(self._query_opcode_metadata_property(gdef.EvtPublisherMetadataOpcodeMessageID))
+
+
+class PublisherMetadataKeyword(object):
+
+    def __init__(self, pub_metadata, channel_id):
+        super(PublisherMetadataKeyword, self).__init__()
+        self.pub_metadata = pub_metadata
+        self._id = channel_id
+
+    def _query_keyword_metadata_property(self, propertyid):
+        return self.pub_metadata.keywordrefs.property(propertyid, self._id)
+
+    @property
+    def name(self):
+        return str(self._query_keyword_metadata_property(gdef.EvtPublisherMetadataKeywordName))
+
+    @property
+    def value(self):
+        return int(self._query_keyword_metadata_property(gdef.EvtPublisherMetadataKeywordValue))
+
+    @property
+    def message_id(self):
+        return int(self._query_keyword_metadata_property(gdef.EvtPublisherMetadataKeywordMessageID))
+
+class PublisherMetadataTask(object):
+
+    def __init__(self, pub_metadata, channel_id):
+        super(PublisherMetadataTask, self).__init__()
+        self.pub_metadata = pub_metadata
+        self._id = channel_id
+
+    def _query_keyword_metadata_property(self, propertyid):
+        return self.pub_metadata.taskrefs.property(propertyid, self._id)
+
+    @property
+    def name(self):
+        return str(self._query_keyword_metadata_property(gdef.EvtPublisherMetadataTaskName))
+
+    @property
+    def value(self):
+        return int(self._query_keyword_metadata_property(gdef.EvtPublisherMetadataTaskValue))
+
+    @property
+    def event_guid(self):
+        return self._query_keyword_metadata_property(gdef.EvtPublisherMetadataTaskEventGuid)
+
+    @property
+    def message_id(self):
+        return int(self._query_keyword_metadata_property(gdef.EvtPublisherMetadataTaskMessageID))
 
 class EvtPublisher(object):
     """An Event provider"""
@@ -495,13 +590,76 @@ class PublisherMetadata(EvtHandle):
         return PropertyArray(publishinfo(self, gdef.EvtPublisherMetadataChannelReferences).value)
 
     @property
-    def channels_metadata(self):
-        """The :class:`ChannelMetadata` for each event this provider defines
+    def levelrefs(self):
+        """Identifies the levels child element of the provider.
 
-        :yield: :class:`ChannelMetadata`
+        :type: :class:`PropertyArray`
         """
-        return [ChannelMetadata(self, i) for i in range(self.chanrefs.size)]
+        return PropertyArray(publishinfo(self, gdef.EvtPublisherMetadataLevels).value)
 
+    @property
+    def opcoderefs(self):
+        """Identifies the opcodes child element of the provider.
+
+        :type: :class:`PropertyArray`
+        """
+        return PropertyArray(publishinfo(self, gdef.EvtPublisherMetadataOpcodes).value)
+
+    @property
+    def keywordrefs(self):
+        """The list of keywords defined by this provider
+
+        :type: :class:`PropertyArray`
+        """
+        return PropertyArray(publishinfo(self, gdef.EvtPublisherMetadataKeywords).value)
+
+    @property
+    def taskrefs(self):
+        """The list of tasks defined by this provider
+
+        :type: :class:`PropertyArray`
+        """
+        return PropertyArray(publishinfo(self, gdef.EvtPublisherMetadataTasks).value)
+
+    @property
+    def channels_metadata(self):
+        """The :class:`PublisherMetadataChannel` for each channel this provider defines
+
+        :yield: :class:`PublisherMetadataChannel`
+        """
+        return [PublisherMetadataChannel(self, i) for i in range(self.chanrefs.size)]
+
+    @property
+    def levels_metadata(self):
+        """The :class:`PublisherMetadataLevel` for each level this provider defines
+
+        :yield: :class:`PublisherMetadataLevel`
+        """
+        return [PublisherMetadataLevel(self, i) for i in range(self.levelrefs.size)]
+
+    @property
+    def opcodes_metadata(self):
+        """The :class:`PublisherMetadataOpcode` for each opcode this provider defines
+
+        :yield: :class:`PublisherMetadataOpcode`
+        """
+        return [PublisherMetadataOpcode(self, i) for i in range(self.opcoderefs.size)]
+
+    @property
+    def tasks_metadata(self):
+        """The :class:`PublisherMetadataTask` for each opcode this provider defines
+
+        :yield: :class:`PublisherMetadataTask`
+        """
+        return [PublisherMetadataTask(self, i) for i in range(self.taskrefs.size)]
+
+    @property
+    def keywords_metadata(self):
+        """The :class:`PublisherMetadataKeyword` for each opcode this provider defines
+
+        :yield: :class:`PublisherMetadataKeyword`
+        """
+        return [PublisherMetadataKeyword(self, i) for i in range(self.keywordrefs.size)]
 
     @property
     def events_metadata(self):

--- a/windows/winobject/event_log.py
+++ b/windows/winobject/event_log.py
@@ -727,6 +727,18 @@ class PublisherMetadata(EvtHandle):
         """
         return publishinfo(self, gdef.EvtPublisherMetadataMessageFilePath).value
 
+    @property
+    def message_resource_filepath(self):
+        """
+        """
+        return publishinfo(self, gdef.EvtPublisherMetadataResourceFilePath).value
+
+    @property
+    def message_parameter_filepath(self):
+        """
+        """
+        return publishinfo(self, gdef.EvtPublisherMetadataParameterFilePath).value
+
 
     def __repr__(self):
         return '<{0} "{1}">'.format(type(self).__name__, self.name)

--- a/windows/winobject/event_trace.py
+++ b/windows/winobject/event_trace.py
@@ -203,6 +203,19 @@ class EtwTrace(object):
             guid = gdef.GUID.from_string(guid)
         return windows.winproxy.EnableTrace(1, flags, level, guid, self.handle) # EnableTraceEx ?
 
+    def enable_ex(self, guid, flags=0xff, level=0xff, any_keyword = 0xffffffff, all_keyword=0x00):
+        if isinstance(guid, basestring):
+            guid = gdef.GUID.from_string(guid)
+
+        # TODO : implement EnableParameters
+        EVENT_CONTROL_CODE_ENABLE_PROVIDER = 1
+
+        # EnableTraceEx only accept a UCHAR for the level param
+        # TODO : maybe raise an Exception instead of silently masking the value ?
+        level = gdef.UCHAR(chr(level & 0xff))
+
+        return windows.winproxy.EnableTraceEx2(self.handle, guid, EVENT_CONTROL_CODE_ENABLE_PROVIDER, level , any_keyword, all_keyword, 0, None) 
+
 
     def process(self, callback, begin=None, end=None):
         if end == "now":


### PR DESCRIPTION
Mamène !

La vie de ma mère, j'ai pas tout compris ce que j'ai charbonné, mais j'te la fait simple le publisher ETW il te dit comment tu dois capischer les petits paquets ETW qu'il te bicrave. Tu peux même découpér tous les param' grasse à un template XML qu'il faut cépar (c'te tchoin) mais après tu as dé jolis messages d'events qui poppe.

Tout ce que j'ai du charreter dans la codebase :

* tu peux donner un objet Python dans la trace, et le récup' dans le context d'un EVENT_RECORD 
* grabber les "keywords" d'un publisher ETW et wrapper a `EnableTraceEx2`,  sinon on loupe des événements.

J't'ai  préparé ce genre de script d'exemple `wevtutil.py`, com' ça pas besoin de prendre la teuté tu le lances et Paf, t'as des lignes qui s'affichent comme dan Matrix !

Wesh avec ce script, tu peux v'la mater tes ketreu DNS qui partent en live :

```
(py2_env) PS PythonForWindowsEventLog> python .\samples\event_log\wevtutil.py start-trace "ETW-MAMENE" "Microsoft-Windows-DNS-Client"
Interface: Ethernet1 Total DNS Server Count: 1 Index: 1 Address: 02000000ac1056010000000000000000 (01)
[....]
DNS query is called for the name notepad-plus-plus.org, type 1, query options 140738562121728, Server List , isNetwork query 0, network index 0, interface index 0, is asynchronous query 0
DNS query is completed for the name notepad-plus-plus.org, type 1, query options 140738562121728 with status 87 Results
DNS query is called for the name notepad-plus-plus.org, type 28, query options 140738562252800, Server List , isNetwork query 0, network index 0, interface index 0, is asynchronous query 0
Network query initiated for the name notepad-plus-plus.org (is parallel query 1) on network index 0 with interface count 2 with first interface name Ethernet1, local addresses fe80::5956:c54b:f1a8:10b8;172.16.86.129 and Dns Servers 172.16.86.1
Cache lookup called for name notepad-plus-plus.org, type 1, options 2392538375938048 and interface index 0
Cache lookup for name notepad-plus-plus.org, type 1 and option 2392538375938048 returned 9701 with results
Query wire called for name notepad-plus-plus.org, type 1, interface index 0 and network index 0
DNS Query sent to DNS Server 172.16.86.1 for name notepad-plus-plus.org and type 1
Name resolution for the name notepad-plus-plus.org timed out after the DNS server 02000035ac1056010000000000000000 did not respond.
DNS Query sent to DNS Server 172.16.86.1 for name notepad-plus-plus.org and type 1
Name resolution for the name notepad-plus-plus.org timed out after the DNS server 02000035ac1056010000000000000000 did not respond.
DNS Query sent to DNS Server 172.16.86.1 for name notepad-plus-plus.org and type 1
Name resolution for the name checkappexec.microsoft.com timed out after the DNS server 02000035ac1056010000000000000000 did not respond.
Query response for name checkappexec.microsoft.com, type 1, interface index 0 and network index 0 returned 1460 with results
Name resolution for the name checkappexec.microsoft.com timed out after none of the configured DNS servers responded.
DNS query is completed for the name checkappexec.microsoft.com, type 28, query options 2251800887582720 with status 1460 Results
DNS query is called for the name au.download.windowsupdate.com, type 28, query options 1073897472, Server List , isNetwork query 0, network index 0, interface index 0, is asynchronous query 0
Network query initiated for the name au.download.windowsupdate.com (is parallel query 1) on network index 0 with interface count 2 with first interface name Ethernet1, local addresses fe80::5956:c54b:f1a8:10b8;172.16.86.129 and Dns Servers 172.16.86.1
Cache lookup called for name au.download.windowsupdate.com, type 1, options 2251800887582720 and interface index 0
Cache lookup for name au.download.windowsupdate.com, type 1 and option 2251800887582720 returned 9701 with results
DNS query is called for the name au.download.windowsupdate.com, type 1, query options 2251803035049992, Server List , isNetwork query 1, network index 0, interface index 0, is asynchronous query 1
DnsQueryEx for the name au.download.windowsupdate.com is pending
[....]
```

téma, il y a cette karba de `"Microsoft-Windows-IE-SmartScreen"` qui te poucave tout ton pron à MS quand tu browse l'internet avec ce navigateur à la bien, mais qui n'a pas de message associés :

```
(py2_env) PS PythonForWindowsEventLog> python .\samples\event_log\wevtutil.py -v start-trace "ETW-MAMENE" "Microsoft-Windows-IE-SmartScreen"
[....]
DEBUG:root:recv event user data: h t t p s : / / l o l o e t r i c o . s t o r e /   ÜÖÖÖÖÖ@@  1 0 4 1 0 0 0 0 | 1 4 3 0 0 0 4 | 0 | A 0 0 0 0 0 6 0 | F C 0 | 0   
DEBUG:root:recv xml template : <template xmlns="http://schemas.microsoft.com/win/2004/08/events">
  <data name="URL" inType="win:UnicodeString" outType="xs:string"/>
  <data name="PCL" inType="win:Double" outType="xs:double"/>
  <data name="THREAT" inType="win:UInt32" outType="xs:unsignedInt"/>
  <data name="Heuristic" inType="win:UnicodeString" outType="xs:string"/>
  <data name="HasAnyInputFields" inType="win:Boolean" outType="xs:boolean"/>
  <data name="HasPasswordField" inType="win:Boolean" outType="xs:boolean"/>
</template>

DEBUG:root:ParsedElement(index=0, name=u'URL', value=u'https://loloetrico.store/', format='s')
DEBUG:root:ParsedElement(index=1, name=u'PCL', value=4617765877924338074L, format='f')
DEBUG:root:ParsedElement(index=2, name=u'THREAT', value=1088, format='d')
DEBUG:root:ParsedElement(index=3, name=u'Heuristic', value=u'10410000|1430004|0|A0000060|FC0|0', format='s')
DEBUG:root:ParsedElement(index=4, name=u'HasAnyInputFields', value=True, format='s')
DEBUG:root:ParsedElement(index=5, name=u'HasPasswordField', value=False, format='s')
DEBUG:root:message params : [ParsedElement(index=0, name=u'URL', value=u'https://loloetrico.store/', format='s'), ParsedElement(index=1, name=u'PCL', value=4617765877924338074L, format='f'), ParsedElement(index=2, name=u'THREAT', value=1088, format='d'), ParsedElement(index=3, name=u'Heuristic', value=u'10410000|1430004|0|A0000060|FC0|0', format='s'), ParsedElement(index=4, name=u'HasAnyInputFields', value=True, format='s'), ParsedElement(index=5, name=u'HasPasswordField', value=False, format='s')]
DEBUG:root:recv event user data: h t t p s : / / l o l o e t r i c o . s t o r e   F
DEBUG:root:recv xml template : <template xmlns="http://schemas.microsoft.com/win/2004/08/events">
  <data name="URL" inType="win:UnicodeString" outType="xs:string"/>
  <data name="LinksCount" inType="win:UInt32" outType="xs:unsignedInt"/>
  <data name="TopTargetCount" inType="win:UInt32" outType="xs:unsignedInt"/>
</template>

DEBUG:root:ParsedElement(index=0, name=u'URL', value=u'https://loloetrico.store', format='s')
DEBUG:root:ParsedElement(index=1, name=u'LinksCount', value=70, format='d')
DEBUG:root:ParsedElement(index=2, name=u'TopTargetCount', value=0, format='d')
DEBUG:root:message params : [ParsedElement(index=0, name=u'URL', value=u'https://loloetrico.store', format='s'), ParsedElement(index=1, name=u'LinksCount', value=70, format='d'), ParsedElement(index=2, name=u'TopTargetCount', value=0, format='d')]
DEBUG:root:recv event user data: h t t p s : / / l o l o e t r i c o . s t o r e /       @          N U L L               P O S T
DEBUG:root:recv xml template : <template xmlns="http://schemas.microsoft.com/win/2004/08/events">
  <data name="URL" inType="win:UnicodeString" outType="xs:string"/>
  <data name="FinalHRESULT" inType="win:UInt32" outType="xs:unsignedInt"/>
  <data name="THREAT" inType="win:UInt32" outType="xs:unsignedInt"/>
  <data name="UrsStatus" inType="win:UInt32" outType="xs:unsignedInt"/>
  <data name="AllUrlsFoundInDat" inType="win:Boolean" outType="xs:boolean"/>
  <data name="BlockedUrl" inType="win:UnicodeString" outType="xs:string"/>
  <data name="IsBlockedUrlTopFrame" inType="win:Boolean" outType="xs:boolean"/>
  <data name="BlockedUrlCategories" inType="win:UInt64" outType="xs:unsignedLong"/>
  <data name="UrlFetchState" inType="win:UnicodeString" outType="xs:string"/>
</template>

DEBUG:root:ParsedElement(index=0, name=u'URL', value=u'https://loloetrico.store/', format='s')
DEBUG:root:ParsedElement(index=1, name=u'FinalHRESULT', value=0, format='d')
DEBUG:root:ParsedElement(index=2, name=u'THREAT', value=1088, format='d')
DEBUG:root:ParsedElement(index=3, name=u'UrsStatus', value=0, format='d')
DEBUG:root:ParsedElement(index=4, name=u'AllUrlsFoundInDat', value=False, format='s')
DEBUG:root:ParsedElement(index=5, name=u'BlockedUrl', value=u'NULL', format='s')
DEBUG:root:ParsedElement(index=6, name=u'IsBlockedUrlTopFrame', value=False, format='s')
DEBUG:root:ParsedElement(index=7, name=u'BlockedUrlCategories', value=0, format='d')
DEBUG:root:ParsedElement(index=8, name=u'UrlFetchState', value=u'POST', format='s')
DEBUG:root:message params : [ParsedElement(index=0, name=u'URL', value=u'https://loloetrico.store/', format='s'), ParsedElement(index=1, name=u'FinalHRESULT', value=0, format='d'), ParsedElement(index=2, name=u'THREAT', value=1088, format='d'), ParsedElement(index=3, name=u'UrsStatus', value=0, format='d'), ParsedElement(index=4, name=u'AllUrlsFoundInDat', value=False, format='s'), ParsedElement(index=5, name=u'BlockedUrl', value=u'NULL', format='s'), ParsedElement(index=6, name=u'IsBlockedUrlTopFrame', value=False, format='s'), ParsedElement(index=7, name=u'BlockedUrlCategories', value=0, format='d'), ParsedElement(index=8, name=u'UrlFetchState', value=u'POST', format='s')]
DEBUG:root:recv event user data: h t t p s : / / w w w . b i n g . c o m / s e a r c h ? q = l o l o + e t + r i c o & s r c = i e - s e a r c h b o x & f o r m = i e s r 4 s
DEBUG:root:recv xml template : <template xmlns="http://schemas.microsoft.com/win/2004/08/events">
  <data name="URL" inType="win:UnicodeString" outType="xs:string"/>
</template>

DEBUG:root:ParsedElement(index=0, name=u'URL', value=u'https://www.bing.com/search?q=lolo+et+rico&src=ie-searchbox&form=iesr4s', format='s')
DEBUG:root:message params : [ParsedElement(index=0, name=u'URL', value=u'https://www.bing.com/search?q=lolo+et+rico&src=ie-searchbox&form=iesr4s', format='s')]
[....]
```

Bon allez je te laisse, 'de parler d'traces ça m'a donné envie de m'en faire 2-3 ! 👃 
