### PR TITLE
add auto-generated functions for event and file mapping

### DIFF
--- a/ctypes_generation/definitions/functions/memoryapi.txt
+++ b/ctypes_generation/definitions/functions/memoryapi.txt
@@ -1,0 +1,18 @@
+
+HANDLE OpenFileMappingW(
+  DWORD   dwDesiredAccess,
+  BOOL    bInheritHandle,
+  LPCWSTR lpName
+);
+
+HANDLE OpenFileMappingA(
+  DWORD  dwDesiredAccess,
+  BOOL   bInheritHandle,
+  LPCSTR lpName
+);
+
+BOOL UnmapViewOfFile(
+  LPCVOID lpBaseAddress
+);
+
+

--- a/ctypes_generation/definitions/functions/synchapi.txt
+++ b/ctypes_generation/definitions/functions/synchapi.txt
@@ -1,0 +1,40 @@
+HANDLE CreateEventA(
+  LPSECURITY_ATTRIBUTES lpEventAttributes,
+  BOOL                  bManualReset,
+  BOOL                  bInitialState,
+  LPCSTR                lpName
+);
+
+HANDLE CreateEventW(
+  LPSECURITY_ATTRIBUTES lpEventAttributes,
+  BOOL                  bManualReset,
+  BOOL                  bInitialState,
+  LPCWSTR               lpName
+);
+
+HANDLE CreateEventExA(
+  LPSECURITY_ATTRIBUTES lpEventAttributes,
+  LPCSTR                lpName,
+  DWORD                 dwFlags,
+  DWORD                 dwDesiredAccess
+);
+
+HANDLE CreateEventExW(
+  LPSECURITY_ATTRIBUTES lpEventAttributes,
+  LPCWSTR               lpName,
+  DWORD                 dwFlags,
+  DWORD                 dwDesiredAccess
+);
+
+HANDLE WINAPI OpenEventA(
+    __in DWORD dwDesiredAccess,
+    __in BOOL bInheritHandle,
+    __in LPCSTR lpName
+);
+
+HANDLE WINAPI OpenEventW(
+    __in DWORD dwDesiredAccess,
+    __in BOOL bInheritHandle,
+    __in LPCWSTR lpName
+);
+

--- a/ctypes_generation/definitions/functions/winfunc.txt
+++ b/ctypes_generation/definitions/functions/winfunc.txt
@@ -812,21 +812,6 @@ NTSTATUS RtlGetCompressionWorkSpaceSize(
 );
 
 
-HANDLE WINAPI OpenEventA(
-    __in DWORD dwDesiredAccess,
-    __in BOOL bInheritHandle,
-    __in LPCSTR lpName
-);
-
-
-HANDLE WINAPI OpenEventW(
-    __in DWORD dwDesiredAccess,
-    __in BOOL bInheritHandle,
-    __in LPCWSTR lpName
-);
-
-
-
 INT WINAPI lstrcmpA(
     __in LPCSTR lpString1,
     __in LPCSTR lpString2

--- a/windows/winproxy/apis/kernel32.py
+++ b/windows/winproxy/apis/kernel32.py
@@ -498,11 +498,21 @@ def CreateFileMappingA(hFile, lpFileMappingAttributes=None, flProtect=gdef.PAGE_
 def CreateFileMappingW(hFile, lpFileMappingAttributes=None, flProtect=gdef.PAGE_READWRITE, dwMaximumSizeHigh=0, dwMaximumSizeLow=0, lpName=NeededParameter):
     return CreateFileMappingW.ctypes_function(hFile, lpFileMappingAttributes, flProtect, dwMaximumSizeHigh, dwMaximumSizeLow, lpName)
 
+@Kernel32Proxy()
+def OpenFileMappingW(dwDesiredAccess, bInheritHandle, lpName):
+    return OpenFileMappingW.ctypes_function(dwDesiredAccess, bInheritHandle, lpName)
+
+@Kernel32Proxy()
+def OpenFileMappingA(dwDesiredAccess, bInheritHandle, lpName):
+    return OpenFileMappingA.ctypes_function(dwDesiredAccess, bInheritHandle, lpName)
 
 @Kernel32Proxy()
 def MapViewOfFile(hFileMappingObject, dwDesiredAccess=gdef.FILE_MAP_ALL_ACCESS, dwFileOffsetHigh=0, dwFileOffsetLow=0, dwNumberOfBytesToMap=NeededParameter):
     return MapViewOfFile.ctypes_function(hFileMappingObject, dwDesiredAccess, dwFileOffsetHigh, dwFileOffsetLow, dwNumberOfBytesToMap)
 
+@Kernel32Proxy()
+def UnmapViewOfFile(lpBaseAddress):
+    return UnmapViewOfFile.ctypes_function(lpBaseAddress)
 
 @Kernel32Proxy()
 def FindFirstFileA(lpFileName, lpFindFileData):
@@ -581,7 +591,23 @@ def OpenEventA(dwDesiredAccess, bInheritHandle, lpName):
 
 @Kernel32Proxy()
 def OpenEventW(dwDesiredAccess, bInheritHandle, lpName):
-    return OpenEventA.ctypes_function(dwDesiredAccess, bInheritHandle, lpName)
+    return OpenEventW.ctypes_function(dwDesiredAccess, bInheritHandle, lpName)
+
+@Kernel32Proxy()
+def CreateEventA(lpEventAttributes, bManualReset, bInitialState, lpName):
+    return CreateEventA.ctypes_function(lpEventAttributes, bManualReset, bInitialState, lpName)
+
+@Kernel32Proxy()
+def CreateEventW(lpEventAttributes, bManualReset, bInitialState, lpName):
+    return CreateEventW.ctypes_function(lpEventAttributes, bManualReset, bInitialState, lpName)
+
+@Kernel32Proxy()
+def CreateEventExA(lpEventAttributes, lpName, dwFlags, dwDesiredAccess):
+    return CreateEventExA.ctypes_function(lpEventAttributes, lpName, dwFlags, dwDesiredAccess)
+
+@Kernel32Proxy()
+def CreateEventExW(lpEventAttributes, lpName, dwFlags, dwDesiredAccess):
+    return CreateEventExW.ctypes_function(lpEventAttributes, lpName, dwFlags, dwDesiredAccess)
 
 
 ## Path


### PR DESCRIPTION
Hello,

This PR add a few functions from `kernel32.dll` to the `generated_def`:

* add the `CreateEvent*` functions, put in `synchapi.txt`, also put the `OpenEvent*` already defined in that file for coherency
* add the `OpenFileMapping*` and `UnmapViewOfFile` functions, put in memoryapi.txt

Name of the `.txt` is derived from the name of the windows header.

This also fix a problem in the definition of the `OpenEventW` where it called `OpenEventA` (https://github.com/hakril/PythonForWindows/blob/master/windows/winproxy/apis/kernel32.py#L584)

I did not push the autogenerated files because I was not sure if you wanted them and it will complexify the review of the commit.

Thanks again for the really usefull project :)