### PR TITLE
Fix TypeError bug

### DIFF
--- a/windows/alpc.py
+++ b/windows/alpc.py
@@ -164,7 +164,7 @@ class AlpcMessagePort(gdef.PORT_MESSAGE):
         if len(data) > self.max_datasize:
             import pdb; pdb.set_trace()
             raise ValueError("Cannot write data of len <{0}> (raw_buffer size == <{1}>)".format(len(data), self.buffer_size))
-        self.raw_buffer[self.header_size: self.header_size + len(data)] = data
+        self.raw_buffer[self.header_size: self.header_size + len(data)] = str.encode(data)
         self.set_datalen(len(data))
 
     data = property(read_data, write_data)


### PR DESCRIPTION
Hi,

Great project.
I used a simple RPC example to run the server.    
I had a bug when I used James Forshaw function `Get-RpcAlpcServer`, from his RPC tool ([NtObjectManager](https://www.powershellgallery.com/packages/NtObjectManager/1.1.32)).   

The application throw an error:
```pyhton
  File "C:\Users\Administrator\AppData\Local\Programs\Python\Python310\lib\site-packages\windows\alpc.py", line 164, in write_data
    self.raw_buffer[self.header_size: self.header_size + len(data)] = data
TypeError: one character bytes, bytearray or integer expected
````  

I fixed it by returning the data as bytes.   
