### PR TITLE
Fix rpc data marshall aligment issue

### DIFF
--- a/windows/rpc/ndr.py
+++ b/windows/rpc/ndr.py
@@ -608,7 +608,7 @@ class NdrWriteStream(object):
         if self.data_size % alignement == 0:
             return
         topadsize = (alignement) - (self.data_size  % alignement)
-        self.write(b"P" * topadsize)
+        self.write(b"\x00" * topadsize)
         return
 
 def make_parameters(types, name=None):


### PR DESCRIPTION
NdrWriteStream object use to marshall data to the memory, however, there's a problem when do alignment. Let' see the rpc interface idl below:

```
int Output2(
	[in] handle_t hBinding,
	[in] short* Output1,
	[in] hyper* Output2);
```

The code we reach the interface:

```
# ...
class Output2(ndr.NdrParameters):
    MEMBERS = [ndr.NdrShort, ndr.NdrHyper]

# ... 
params = Output2.pack([0x4242, 0x4141414141414141])
# ...
```

We observed the server side argument memory:

```
000001f2`8bd2d1f8  50505050`50504040 41414141`41414141
000001f2`8bd2d208  00000000`00000000 00000000`00000000
000001f2`8bd2d218  00000000`00000000 00000000`00000000
```

Althougth the data successful passed to the serverside with no unmarshall error, the padding data `P` cause confusion for me when I do rpc research, especially when it these simple type stored into structure. Hope this patch can fix this problem, thanks!