### PR TITLE
Improved behavior when running under Microsoft Store python interpreters

### DIFF
--- a/docs/build/html/process.html
+++ b/docs/build/html/process.html
@@ -582,8 +582,8 @@
 raises an exception if the remote thread raised one</p>
 <div class="admonition note">
 <p class="admonition-title">Note</p>
-<p>This method is incompatible with Microsoft Store builds of python, as the interpreter DLLs do not grant execute to Users,
-see workaround:  <a class="reference external" href="https://github.com/hakril/PythonForWindows/tree/master/samples/process/msstore_interpreter_remote_python.py">https://github.com/hakril/PythonForWindows/tree/master/samples/process/msstore_interpreter_remote_python.py</a></p>
+<p>This method is incompatible with Microsoft Store builds of python, as the interpreter DLLs do not grant execute to Users.
+See workaround:  <a class="reference external" href="https://github.com/hakril/PythonForWindows/tree/master/samples/process/msstore_interpreter_remote_python.py">https://github.com/hakril/PythonForWindows/tree/master/samples/process/msstore_interpreter_remote_python.py</a></p>
 </div>
 </dd></dl>
 
@@ -603,8 +603,8 @@ see workaround:  <a class="reference external" href="https://github.com/hakril/P
 </dl>
 <div class="admonition note">
 <p class="admonition-title">Note</p>
-<p>This method is incompatible with Microsoft Store builds of python, as the interpreter DLLs do not grant execute to Users,
-see workaround:  <a class="reference external" href="https://github.com/hakril/PythonForWindows/tree/master/samples/process/msstore_interpreter_remote_python.py">https://github.com/hakril/PythonForWindows/tree/master/samples/process/msstore_interpreter_remote_python.py</a></p>
+<p>This method is incompatible with Microsoft Store builds of python, as the interpreter DLLs do not grant execute to Users.
+See workaround:  <a class="reference external" href="https://github.com/hakril/PythonForWindows/tree/master/samples/process/msstore_interpreter_remote_python.py">https://github.com/hakril/PythonForWindows/tree/master/samples/process/msstore_interpreter_remote_python.py</a></p>
 </div>
 </dd></dl>
 

--- a/docs/build/html/process.html
+++ b/docs/build/html/process.html
@@ -577,15 +577,20 @@
 <dl class="py method">
 <dt class="sig sig-object py" id="windows.winobject.process.WinProcess.execute_python">
 <span class="sig-name descname"><span class="pre">execute_python</span></span><span class="sig-paren">(</span><em class="sig-param"><span class="n"><span class="pre">pycode</span></span></em><span class="sig-paren">)</span><a class="reference internal" href="_modules/windows/winobject/process.html#WinProcess.execute_python"><span class="viewcode-link"><span class="pre">[source]</span></span></a><a class="headerlink" href="#windows.winobject.process.WinProcess.execute_python" title="Link to this definition">¶</a></dt>
-<dd><p>Execute Python code into the remote process.</p>
+<dd><p>Execute Python code in the remote process.</p>
 <p>This function waits for the remote process to end and
 raises an exception if the remote thread raised one</p>
+<div class="admonition note">
+<p class="admonition-title">Note</p>
+<p>This method is incompatible with Microsoft Store builds of python, as the interpreter DLLs do not grant execute to Users,
+see workaround:  <a class="reference external" href="https://github.com/hakril/PythonForWindows/tree/master/samples/process/msstore_interpreter_remote_python.py">https://github.com/hakril/PythonForWindows/tree/master/samples/process/msstore_interpreter_remote_python.py</a></p>
+</div>
 </dd></dl>
 
 <dl class="py method">
 <dt class="sig sig-object py" id="windows.winobject.process.WinProcess.execute_python_unsafe">
 <span class="sig-name descname"><span class="pre">execute_python_unsafe</span></span><span class="sig-paren">(</span><em class="sig-param"><span class="n"><span class="pre">pycode</span></span></em><span class="sig-paren">)</span><a class="reference internal" href="_modules/windows/winobject/process.html#WinProcess.execute_python_unsafe"><span class="viewcode-link"><span class="pre">[source]</span></span></a><a class="headerlink" href="#windows.winobject.process.WinProcess.execute_python_unsafe" title="Link to this definition">¶</a></dt>
-<dd><p>Execute Python code into the remote process.</p>
+<dd><p>Execute Python code in the remote process.</p>
 <dl class="field-list simple">
 <dt class="field-odd">Return type<span class="colon">:</span></dt>
 <dd class="field-odd"><p><dl class="field-list simple">
@@ -596,6 +601,11 @@ raises an exception if the remote thread raised one</p>
 </p>
 </dd>
 </dl>
+<div class="admonition note">
+<p class="admonition-title">Note</p>
+<p>This method is incompatible with Microsoft Store builds of python, as the interpreter DLLs do not grant execute to Users,
+see workaround:  <a class="reference external" href="https://github.com/hakril/PythonForWindows/tree/master/samples/process/msstore_interpreter_remote_python.py">https://github.com/hakril/PythonForWindows/tree/master/samples/process/msstore_interpreter_remote_python.py</a></p>
+</div>
 </dd></dl>
 
 <dl class="py method">

--- a/docs/source/sample.rst
+++ b/docs/source/sample.rst
@@ -69,6 +69,20 @@ Output
 
 .. _token_sample:
 
+
+Microsoft Store Python Injection
+''''''''''''''''''''''''''''''''
+
+Python execution in remote process fails with Microsoft Store builds of pythons (`mspython`), as the interpreter DLLs do not grant execute to Users.
+This sample shows a workaround by user https://github.com/dariushoule by copying needed mspython files to a temporary directory and injecting those instead.
+
+.. literalinclude:: ..\..\samples\process\msstore_interpreter_remote_python.py
+
+Output
+
+.. literalinclude:: samples_output\process_msstore_interpreter_remote_python.txt
+
+
 Token
 """""
 

--- a/docs/source/samples_output/process_msstore_interpreter_remote_python.txt
+++ b/docs/source/samples_output/process_msstore_interpreter_remote_python.txt
@@ -1,0 +1,15 @@
+PS C:\Users\hakril\PythonForWindows> py .\samples\process\msstore_interpreter_remote_python.py
+Executable is: C:\Users\hakril\AppData\Local\Microsoft\WindowsApps\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\python.exe
+Trying normal execute_python()
+    Exception during proc1.execute_python():
+    InjectionFailedError('Injection of <c:\\program files\\windowsapps\\pythonsoftwarefoundation.python.3.13_3.13.496.0_x64__qbz5n2kfra8p0\\vcruntime140.dll> failed')
+Trying mspython workaround:
+    Executing python code!
+Injecting: C:\Users\hakril\AppData\Local\Temp\pfw_dllcache\vcruntime140.dll
+Injecting: C:\Users\hakril\AppData\Local\Temp\pfw_dllcache\python313.dll
+    Executing more python code!
+    Executing an error python code!
+        Expected error during safe_execute_python
+        b'Traceback (most recent call last):\n  File "<string>", line 1, in <module>\nNameError: name \'BAD_VARIABLE\' is not defined\n'
+   Sleeping a little
+   Killing target process !

--- a/samples/process/msstore_interpreter_remote_python.py
+++ b/samples/process/msstore_interpreter_remote_python.py
@@ -1,0 +1,111 @@
+# Some python interpreters run in environments with restrictive ACLs (no Users/* execute) on bundled DLLs. 
+# The Microsoft Store version of python is the prime example of this. 
+# 
+# Remote execution of python is still possible by creating a minimal set of the dependencies outside of the restricted directory. 
+#
+# This can be very helpful when operating PFW in environments with restrive GPOs / AppLocker.
+
+
+import ctypes
+import glob
+import os
+import shutil
+import tempfile
+import time
+
+import windows
+from windows.generated_def.ntstatus import STATUS_THREAD_IS_TERMINATING
+from windows.generated_def.windef import CREATE_SUSPENDED
+from windows.generated_def.winstructs import PROCESS_INFORMATION, STARTUPINFOW
+from windows.injection import RemotePythonError, \
+    find_python_dll_to_inject, get_dll_name_from_python_version, inject_python_command, load_dll_in_remote_process, retrieve_last_exception_data
+
+
+CACHE_DIR = os.path.join(tempfile.gettempdir(), 'pfw_dllcache')
+INTERPRETER_DIR = os.path.dirname(find_python_dll_to_inject(64)) # Tailor bitness to your needs
+
+
+def mspython_acl_workaround(target, pydll_path):
+    """
+    Works around mspython ACL restrictions on mspython interpreters
+    by copying the critical DLLs to a TEMP dir and orienting the interpreter 
+    against that TEMP dir. 
+    """
+
+    if not os.path.exists(CACHE_DIR):
+        os.mkdir(CACHE_DIR)
+
+    for dll in [os.path.join(INTERPRETER_DIR, 'vcruntime140.dll'), pydll_path]:
+        cache_dll_path = os.path.join(CACHE_DIR, os.path.basename(dll))
+        try:
+            # Creates a copy of the DLL without bringing over restrictive ACLs
+            shutil.copyfile(dll, cache_dll_path)
+        except:
+            # If its not writeable good chance these DLLs are just already loaded somewhere
+            pass
+        # Preloading python DLL and vcruntime so they don't get loaded from the path tree with restrictive ACLs
+        load_dll_in_remote_process(target, cache_dll_path)
+
+    for dll in glob.glob(os.path.join(INTERPRETER_DIR, 'dlls', '*')):
+        cache_dll_path = os.path.join(CACHE_DIR, os.path.basename(dll))
+        try:
+            # Dynamic lib DLLs with restrictive ACLs copied to unrestricted parent
+            shutil.copyfile(dll, cache_dll_path)
+        except:
+            pass
+
+
+# Adapted from windows\winobject\process.py
+def execute_python_code(process, code):
+    py_dll_name = get_dll_name_from_python_version()
+    pydll_path = find_python_dll_to_inject(process.bitness)
+    
+    mspython_acl_workaround(process, pydll_path)
+    shellcode, pythoncode = inject_python_command(process, code, py_dll_name)
+    t = process.create_thread(shellcode, pythoncode)
+    return t
+
+
+def safe_execute_python(process, code):
+    t = execute_python_code(process, code)
+    t.wait() # Wait termination of the thread
+    if t.exit_code == 0:
+        return True
+    if t.exit_code == STATUS_THREAD_IS_TERMINATING or process.is_exit:
+        raise WindowsError("{0} died during execution of python command".format(process))
+    if t.exit_code != 0xffffffff:
+        raise ValueError("Unknown exit code {0}".format(hex(t.exit_code)))
+    data = retrieve_last_exception_data(process)
+    raise RemotePythonError(data)
+
+
+print("Starting target")
+proc_info = PROCESS_INFORMATION()
+StartupInfo = STARTUPINFOW()
+StartupInfo.cb = ctypes.sizeof(StartupInfo)
+windows.winproxy.CreateProcessW(
+    r"C:\Windows\system32\winver.exe", 
+    dwCreationFlags=CREATE_SUSPENDED, 
+    # Point PYTHONHOME to the interpreter dir so non-DLL libs can load
+    # Point PYTHONPATH to the newly created cache directory so DLL libs are loaded from there
+    lpEnvironment=('\0'.join('{}={}'.format(e, v) for e, v in os.environ.items()) + \
+                   '\0PYTHONHOME={}\0PYTHONPATH={}\0\0'.format(INTERPRETER_DIR, CACHE_DIR)).encode(),
+    lpProcessInformation=ctypes.byref(proc_info), 
+    lpStartupInfo=ctypes.byref(StartupInfo))
+process = windows.winobject.process.WinProcess(pid=proc_info.dwProcessId, handle=proc_info.hProcess)
+
+print("Executing python code!")
+safe_execute_python(process, """
+import windows
+windows.utils.create_console()
+print('hello from inside the suspended process!', flush=True)
+""")
+
+process.threads[0].resume()
+
+print("Executing more python code!")
+safe_execute_python(process, """
+print('hello from inside the resumed process!', flush=True)
+""")
+
+process.wait()

--- a/samples/process/msstore_interpreter_remote_python.py
+++ b/samples/process/msstore_interpreter_remote_python.py
@@ -1,7 +1,7 @@
-# Some python interpreters run in environments with restrictive ACLs (no Users/* execute) on bundled DLLs. 
-# The Microsoft Store version of python is the prime example of this. 
-# 
-# Remote execution of python is still possible by creating a minimal set of the dependencies outside of the restricted directory. 
+# Some python interpreters run in environments with restrictive ACLs (no Users/* execute) on bundled DLLs.
+# The Microsoft Store version of python is the prime example of this.
+#
+# Remote execution of python is still possible by creating a minimal set of the dependencies outside of the restricted directory.
 #
 # This can be very helpful when operating PFW in environments with restrive GPOs / AppLocker.
 
@@ -12,14 +12,18 @@ import os
 import shutil
 import tempfile
 import time
+import sys
+import struct
 
 import windows
 from windows.generated_def.ntstatus import STATUS_THREAD_IS_TERMINATING
 from windows.generated_def.windef import CREATE_SUSPENDED
 from windows.generated_def.winstructs import PROCESS_INFORMATION, STARTUPINFOW
 from windows.injection import RemotePythonError, \
-    find_python_dll_to_inject, get_dll_name_from_python_version, inject_python_command, load_dll_in_remote_process, retrieve_last_exception_data
+    find_python_dll_to_inject, get_dll_name_from_python_version, inject_python_command, load_dll_in_remote_process, retrieve_exc
 
+
+print("Executable is: {0}".format(sys.executable))
 
 CACHE_DIR = os.path.join(tempfile.gettempdir(), 'pfw_dllcache')
 INTERPRETER_DIR = os.path.dirname(find_python_dll_to_inject(64)) # Tailor bitness to your needs
@@ -28,8 +32,8 @@ INTERPRETER_DIR = os.path.dirname(find_python_dll_to_inject(64)) # Tailor bitnes
 def mspython_acl_workaround(target, pydll_path):
     """
     Works around mspython ACL restrictions on mspython interpreters
-    by copying the critical DLLs to a TEMP dir and orienting the interpreter 
-    against that TEMP dir. 
+    by copying the critical DLLs to a TEMP dir and orienting the interpreter
+    against that TEMP dir.
     """
 
     if not os.path.exists(CACHE_DIR):
@@ -40,10 +44,12 @@ def mspython_acl_workaround(target, pydll_path):
         try:
             # Creates a copy of the DLL without bringing over restrictive ACLs
             shutil.copyfile(dll, cache_dll_path)
-        except:
+        except Exception as e:
             # If its not writeable good chance these DLLs are just already loaded somewhere
-            pass
+            print(e)
+
         # Preloading python DLL and vcruntime so they don't get loaded from the path tree with restrictive ACLs
+        print("Injecting: {0}".format(cache_dll_path))
         load_dll_in_remote_process(target, cache_dll_path)
 
     for dll in glob.glob(os.path.join(INTERPRETER_DIR, 'dlls', '*')):
@@ -51,16 +57,19 @@ def mspython_acl_workaround(target, pydll_path):
         try:
             # Dynamic lib DLLs with restrictive ACLs copied to unrestricted parent
             shutil.copyfile(dll, cache_dll_path)
-        except:
-            pass
+        except Exception as e:
+            print(e)
+
+    target._workaround_applied = True
 
 
 # Adapted from windows\winobject\process.py
 def execute_python_code(process, code):
     py_dll_name = get_dll_name_from_python_version()
     pydll_path = find_python_dll_to_inject(process.bitness)
-    
-    mspython_acl_workaround(process, pydll_path)
+
+    if not getattr(process, "_workaround_applied", None):
+        mspython_acl_workaround(process, pydll_path)
     shellcode, pythoncode = inject_python_command(process, code, py_dll_name)
     t = process.create_thread(shellcode, pythoncode)
     return t
@@ -78,23 +87,41 @@ def safe_execute_python(process, code):
     data = retrieve_last_exception_data(process)
     raise RemotePythonError(data)
 
+# Adapted from windows\injection.py
+def retrieve_last_exception_data(process):
+    with process.allocated_memory(0x1000) as mem:
+        execute_python_code(process, retrieve_exc.format(mem)).wait()
+        size = struct.unpack("<I", process.read_memory(mem, ctypes.sizeof(ctypes.c_uint)))[0]
+        data = process.read_memory(mem + ctypes.sizeof(ctypes.c_uint), size)
+    return data
 
-print("Starting target")
+# First: show what happen when injecting mspython normally
+print("Trying normal execute_python()")
+proc1 = windows.utils.create_process(r"C:\Windows\system32\winver.exe")
+try:
+    proc1.execute_python("2 + 2 == 5")
+except Exception as e:
+    print("    Exception during proc1.execute_python():")
+    print("    {0}".format(repr(e)))
+proc1.exit()
+
+print("Trying mspython workaround:")
 proc_info = PROCESS_INFORMATION()
 StartupInfo = STARTUPINFOW()
 StartupInfo.cb = ctypes.sizeof(StartupInfo)
 windows.winproxy.CreateProcessW(
-    r"C:\Windows\system32\winver.exe", 
-    dwCreationFlags=CREATE_SUSPENDED, 
+    r"C:\Windows\system32\winver.exe",
+    dwCreationFlags=CREATE_SUSPENDED,
     # Point PYTHONHOME to the interpreter dir so non-DLL libs can load
     # Point PYTHONPATH to the newly created cache directory so DLL libs are loaded from there
     lpEnvironment=('\0'.join('{}={}'.format(e, v) for e, v in os.environ.items()) + \
                    '\0PYTHONHOME={}\0PYTHONPATH={}\0\0'.format(INTERPRETER_DIR, CACHE_DIR)).encode(),
-    lpProcessInformation=ctypes.byref(proc_info), 
+    lpProcessInformation=ctypes.byref(proc_info),
     lpStartupInfo=ctypes.byref(StartupInfo))
+
 process = windows.winobject.process.WinProcess(pid=proc_info.dwProcessId, handle=proc_info.hProcess)
 
-print("Executing python code!")
+print("    Executing python code!")
 safe_execute_python(process, """
 import windows
 windows.utils.create_console()
@@ -103,9 +130,19 @@ print('hello from inside the suspended process!', flush=True)
 
 process.threads[0].resume()
 
-print("Executing more python code!")
+print("    Executing more python code!")
 safe_execute_python(process, """
 print('hello from inside the resumed process!', flush=True)
 """)
 
-process.wait()
+print("    Executing an error python code!")
+try:
+    safe_execute_python(process, """BAD_VARIABLE""")
+except RemotePythonError as e:
+    print("        Expected error during safe_execute_python")
+    print("        {0}".format(e))
+
+print("   Sleeping a little")
+time.sleep(5)
+print("   Killing target process !")
+process.exit()

--- a/windows/com.py
+++ b/windows/com.py
@@ -33,7 +33,13 @@ def init():
     return initsecurity()
 
 def initsecurity(): # Should take some parameters..
-    return winproxy.CoInitializeSecurity(0, -1, None, 0, 0, RPC_C_IMP_LEVEL_IMPERSONATE, 0,0,0)
+    try:
+        winproxy.CoInitializeSecurity(0, -1, None, 0, 0, RPC_C_IMP_LEVEL_IMPERSONATE, 0,0,0)
+    except OSError as e:
+        if e.winerror & 0xFFFFFFFF != gdef.RPC_E_TOO_LATE:
+            # RPC_E_TOO_LATE can happen when the python environment invokes CoInitializeSecurity before we get to it
+            # mspython builds do this consistently.
+            raise e
 
 
 class Dispatch(interfaces.IDispatch):

--- a/windows/injection.py
+++ b/windows/injection.py
@@ -389,6 +389,13 @@ def execute_python_code(process, code):
     # Cache the value ?
     py_dll_name = get_dll_name_from_python_version()
     pydll_path = find_python_dll_to_inject(process.bitness)
+
+    # NB: Sandboxing on Windows Store apps prevents remote loading DLLs stored under "C:\Program Files*\WindowsApps\*"
+    # This is relevant for remote python execution, as the sandboxed python process is the _only_ one that can 
+    # access its CRT and shared libraries.
+    if '\\windowsapps\\' in pydll_path.lower():
+        raise ValueError('Cannot execute remote python code from a sandboxed python interpreter. Install python outside of the Microsoft Store to resolve.')
+
     if sys.version_info.major == 3:
         # FOr py3, we may have a per-user install.
         # Meaning that the vcruntime140.dll will not be in the injected process path

--- a/windows/injection.py
+++ b/windows/injection.py
@@ -389,13 +389,6 @@ def execute_python_code(process, code):
     # Cache the value ?
     py_dll_name = get_dll_name_from_python_version()
     pydll_path = find_python_dll_to_inject(process.bitness)
-
-    # NB: Sandboxing on Windows Store apps prevents remote loading DLLs stored under "C:\Program Files*\WindowsApps\*"
-    # This is relevant for remote python execution, as the sandboxed python process is the _only_ one that can 
-    # access its CRT and shared libraries.
-    if '\\windowsapps\\' in pydll_path.lower():
-        raise ValueError('Cannot execute remote python code from a sandboxed python interpreter. Install python outside of the Microsoft Store to resolve.')
-
     if sys.version_info.major == 3:
         # FOr py3, we may have a per-user install.
         # Meaning that the vcruntime140.dll will not be in the injected process path

--- a/windows/winobject/process.py
+++ b/windows/winobject/process.py
@@ -1134,7 +1134,7 @@ class WinProcess(Process):
 
         .. note::
             This method is incompatible with Microsoft Store builds of python, as the interpreter DLLs do not grant execute to Users.
-            See workaround:  https://github.com/hakril/PythonForWindows/tree/master/samples/process/msstore_interpreter_remote_python.py
+            See workaround:  https://hakril.github.io/PythonForWindows/build/html/sample.html#microsoft-store-python-injection
         """
         return injection.safe_execute_python(self, pycode)
 
@@ -1145,7 +1145,7 @@ class WinProcess(Process):
 
         .. note::
             This method is incompatible with Microsoft Store builds of python, as the interpreter DLLs do not grant execute to Users.
-            See workaround:  https://github.com/hakril/PythonForWindows/tree/master/samples/process/msstore_interpreter_remote_python.py
+            See workaround:  https://hakril.github.io/PythonForWindows/build/html/sample.html#microsoft-store-python-injection
         """
         return injection.execute_python_code(self, pycode)
 

--- a/windows/winobject/process.py
+++ b/windows/winobject/process.py
@@ -1129,21 +1129,23 @@ class WinProcess(Process):
     def execute_python(self, pycode):
         """Execute Python code in the remote process.
 
-        This method is incompatible with Microsoft Store builds of python, as the interpreter DLLs do not grant execute to Users/*.
-        See: samples/process/msstore_interpreter_remote_python.py for a workaround.
-
         This function waits for the remote process to end and
         raises an exception if the remote thread raised one
-		"""
+
+        .. note::
+            This method is incompatible with Microsoft Store builds of python, as the interpreter DLLs do not grant execute to Users.
+            See workaround:  https://github.com/hakril/PythonForWindows/tree/master/samples/process/msstore_interpreter_remote_python.py
+        """
         return injection.safe_execute_python(self, pycode)
 
     def execute_python_unsafe(self, pycode):
         """Execute Python code in the remote process.
 
-        This method is incompatible with Microsoft Store builds of python, as the interpreter DLLs do not grant execute to Users/*.
-        See: samples/process/msstore_interpreter_remote_python.py for a workaround.
-
         :rtype: :rtype: :class:`WinThread` or :class:`DeadThread` : The thread executing the python code
+
+        .. note::
+            This method is incompatible with Microsoft Store builds of python, as the interpreter DLLs do not grant execute to Users.
+            See workaround:  https://github.com/hakril/PythonForWindows/tree/master/samples/process/msstore_interpreter_remote_python.py
         """
         return injection.execute_python_code(self, pycode)
 

--- a/windows/winobject/process.py
+++ b/windows/winobject/process.py
@@ -1127,7 +1127,10 @@ class WinProcess(Process):
         return [m for m in self.peb.modules if m.baseaddr == dllbase][0]
 
     def execute_python(self, pycode):
-        """Execute Python code into the remote process.
+        """Execute Python code in the remote process.
+
+        This method is incompatible with Microsoft Store builds of python, as the interpreter DLLs do not grant execute to Users/*.
+        See: samples/process/msstore_interpreter_remote_python.py for a workaround.
 
         This function waits for the remote process to end and
         raises an exception if the remote thread raised one
@@ -1135,7 +1138,10 @@ class WinProcess(Process):
         return injection.safe_execute_python(self, pycode)
 
     def execute_python_unsafe(self, pycode):
-        """Execute Python code into the remote process.
+        """Execute Python code in the remote process.
+
+        This method is incompatible with Microsoft Store builds of python, as the interpreter DLLs do not grant execute to Users/*.
+        See: samples/process/msstore_interpreter_remote_python.py for a workaround.
 
         :rtype: :rtype: :class:`WinThread` or :class:`DeadThread` : The thread executing the python code
         """


### PR DESCRIPTION
Proposing a small changeset as a result of investigating https://github.com/hakril/PythonForWindows/issues/72

What I've discovered is the windows store build of python is sandboxed - meaning other processes cannot access its runtime. This is the security configuration of windows store apps by default. So `pythonXX.dll` and others are set as such they're not executable in the remote process and `LoadLibraryA` yields an `ERROR_ACCESS_DENIED`.

I toyed with the idea of automatically copying the interpreter outside of the sandbox to work around, as well as prompting for UAC elevation to apply more open ACLs as a convenience. Ultimately I think the best option here is probably just going to be telling the user that sandboxed python installations are incompatible with the remote python execution feature. The other options I explored are filled with edge cases and thorny-bits. Open to thoughts 🧠 

As it stands you'll find three changes in this MR:

1. Fix `test_get_current_process_modules`, which failed on Microsoft Store builds of python because the app execution alias filename doesn't match the PEB. If we lean on `GetModuleFileNameA` we avoid the confusion caused by the NTFS reparse points.

2. Fix `test_current_process_pe_imports` which failed on Microsoft Store builds of python because the store builds have no direct dependency on `kernel32.dll`. I am proposing that we instead look for the python DLL dependency which we know will _always_ be present, and rely on the first imported method. 
![image](https://github.com/user-attachments/assets/4fa61084-8d34-4f4e-bf92-4b31763d0226)

3. Lastly, if attempting remote python execution on a sandboxed python interpreter the library now provides a helpful error message explaining why the operation would ultimately fail. 

* Tested this on python 2/3 to make sure I did my best to avoid regressing compatibility. 