### PR TITLE
Improve injection error reporting

### DIFF
--- a/tests/test_injection.py
+++ b/tests/test_injection.py
@@ -4,6 +4,7 @@ import pytest
 import weakref
 import shutil
 import time
+import os
 
 import windows
 import windows.generated_def as gdef
@@ -35,8 +36,9 @@ def proc_3264_runsus(request):
 # Its really the same test as test_process.test_load_library but with suspended process as well
 def test_dll_injection(proc_3264_runsus):
     assert (not proc_3264_runsus.peb.Ldr) or ("wintrust.dll" not in [mod.name for mod in proc_3264_runsus.peb.modules])
-    windows.injection.load_dll_in_remote_process(proc_3264_runsus, "wintrust.dll")
-    assert "wintrust.dll" in [mod.name for mod in proc_3264_runsus.peb.modules]
+    modaddr = windows.injection.load_dll_in_remote_process(proc_3264_runsus, "wintrust.dll")
+    wintrustmod = [mod for mod in proc_3264_runsus.peb.modules if mod.name == "wintrust.dll"][0]
+    assert wintrustmod.baseaddr == modaddr
 
 def test_dll_injection_error_reporting(proc_3264_runsus):
     with pytest.raises(windows.injection.InjectionFailedError) as excinfo:

--- a/tests/test_injection.py
+++ b/tests/test_injection.py
@@ -1,35 +1,54 @@
 # -*- coding: utf-8 -*-
 import pytest
 
-import os
-import sys
-import time
-import struct
-import textwrap
+import weakref
 import shutil
+import time
 
 import windows
 import windows.generated_def as gdef
 
-from .pfwtest import *
+from .conftest import pop_proc_32, pop_proc_64
+from .pfwtest import DEFAULT_CREATION_FLAGS
 
-# Its really the same test as test_process.test_load_library
-def test_dll_injection(proc32_64):
-    assert "wintrust.dll" not in [mod.name for mod in proc32_64.peb.modules]
-    windows.injection.load_dll_in_remote_process(proc32_64, "wintrust.dll")
-    assert "wintrust.dll" in [mod.name for mod in proc32_64.peb.modules]
+@pytest.fixture(params=
+    [(pop_proc_32, DEFAULT_CREATION_FLAGS),
+    (pop_proc_32, gdef.CREATE_SUSPENDED),
+    (pop_proc_64, DEFAULT_CREATION_FLAGS),
+    (pop_proc_64, gdef.CREATE_SUSPENDED)],
+    ids=["proc32", "proc32susp", "proc64", "proc64susp"])
+def proc_3264_runsus(request):
+    """Fixture for process 32/64 both running & suspended"""
+    proc_poper, dwCreationFlags = request.param
+    proc = proc_poper(dwCreationFlags=dwCreationFlags)
+    time.sleep(0.2) # Give time to the process to load :)
+    print("Created {0} ({1}bits) for test".format(proc, proc.bitness))
+    yield weakref.proxy(proc)  # provide the fixture value
+    try:
+        proc.exit(0)
+    except WindowsError as e:
+        if not proc.is_exit:
+            raise
+    # print("DEL PROC")
+    del proc
 
-def test_dll_injection_error_reporting(proc32_64):
+# Its really the same test as test_process.test_load_library but with suspended process as well
+def test_dll_injection(proc_3264_runsus):
+    assert (not proc_3264_runsus.peb.Ldr) or ("wintrust.dll" not in [mod.name for mod in proc_3264_runsus.peb.modules])
+    windows.injection.load_dll_in_remote_process(proc_3264_runsus, "wintrust.dll")
+    assert "wintrust.dll" in [mod.name for mod in proc_3264_runsus.peb.modules]
+
+def test_dll_injection_error_reporting(proc_3264_runsus):
     with pytest.raises(windows.injection.InjectionFailedError) as excinfo:
-        windows.injection.load_dll_in_remote_process(proc32_64, "NO_A_DLL.dll")
+        windows.injection.load_dll_in_remote_process(proc_3264_runsus, "NO_A_DLL.dll")
     assert excinfo.value.__cause__.winerror == gdef.ERROR_MOD_NOT_FOUND
 
-def test_dll_injection_access_denied(proc32_64, tmpdir):
+def test_dll_injection_access_denied(proc_3264_runsus, tmpdir):
         """Emulate injection of MsStore python, were its DLL are not executable by any other append
         See: https://github.com/hakril/PythonForWindows/issues/72
         """
         mybitness = windows.current_process.bitness
-        if proc32_64.bitness == mybitness:
+        if proc_3264_runsus.bitness == mybitness:
             DLLPATH = r"c:\windows\system32\wintrust.dll"
         elif mybitness == 64: # target is 32
             DLLPATH = r"c:\windows\syswow64\wintrust.dll"
@@ -45,10 +64,10 @@ def test_dll_injection_access_denied(proc32_64, tmpdir):
 
         try:
             with pytest.raises(windows.injection.InjectionFailedError) as excinfo:
-                windows.injection.load_dll_in_remote_process(proc32_64, targetname)
+                windows.injection.load_dll_in_remote_process(proc_3264_runsus, targetname)
             assert excinfo.value.__cause__.winerror == gdef.ERROR_ACCESS_DENIED
         finally:
-            proc32_64.exit()
-            proc32_64.wait()
+            proc_3264_runsus.exit()
+            proc_3264_runsus.wait()
             time.sleep(0.5) # Fail on Azure CI of no sleep
             os.unlink(targetname)

--- a/tests/test_injection.py
+++ b/tests/test_injection.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+import pytest
+
+import os
+import sys
+import time
+import struct
+import textwrap
+import shutil
+
+import windows
+import windows.generated_def as gdef
+
+from .pfwtest import *
+
+# Its really the same test as test_process.test_load_library
+def test_dll_injection(proc32_64):
+    assert "wintrust.dll" not in [mod.name for mod in proc32_64.peb.modules]
+    windows.injection.load_dll_in_remote_process(proc32_64, "wintrust.dll")
+    assert "wintrust.dll" in [mod.name for mod in proc32_64.peb.modules]
+
+def test_dll_injection_error_reporting(proc32_64):
+    with pytest.raises(windows.injection.InjectionFailedError) as excinfo:
+        windows.injection.load_dll_in_remote_process(proc32_64, "NO_A_DLL.dll")
+    assert excinfo.value.__cause__.winerror == gdef.ERROR_MOD_NOT_FOUND
+
+def test_dll_injection_access_denied(proc32_64, tmpdir):
+        """Emulate injection of MsStore python, were its DLL are not executable by any other append
+        See: https://github.com/hakril/PythonForWindows/issues/72
+        """
+        mybitness = windows.current_process.bitness
+        if proc32_64.bitness == mybitness:
+            DLLPATH = r"c:\windows\system32\wintrust.dll"
+        elif mybitness == 64: # target is 32
+            DLLPATH = r"c:\windows\syswow64\wintrust.dll"
+        elif mybitness == 32: # target is 64
+            DLLPATH = r"c:\windows\sysnative\wintrust.dll"
+        else:
+            raise Value("WTF ARE THE BITNESS ?")
+        targetname = os.path.join(str(tmpdir), "wintrust_noexec.dll")
+        shutil.copy(DLLPATH, targetname)
+        # Deny Execute; allow read for everyone
+        sd = windows.security.SecurityDescriptor.from_string("D:(D;;GXFX;;;WD)(A;;1;;;WD)")
+        sd.to_filename(targetname)
+
+        try:
+            with pytest.raises(windows.injection.InjectionFailedError) as excinfo:
+                windows.injection.load_dll_in_remote_process(proc32_64, targetname)
+            assert excinfo.value.__cause__.winerror == gdef.ERROR_ACCESS_DENIED
+        finally:
+            proc32_64.exit()
+            proc32_64.wait()
+            time.sleep(0.5) # Fail on Azure CI of no sleep
+            os.unlink(targetname)

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -370,6 +370,11 @@ class TestProcessWithCheckGarbage(object):
         proc32_64.load_library(DLL)
         assert DLL in [m.name for m in proc32_64.peb.modules]
 
+    def test_load_library_suspended(self, proc32_64_suspended):
+        DLL = "wintrust.dll"
+        proc32_64_suspended.load_library(DLL)
+        assert DLL in [m.name for m in proc32_64_suspended.peb.modules]
+
     def test_load_library_unicode_name(self, proc32_64, tmpdir):
         mybitness = windows.current_process.bitness
         UNICODE_FILENAME = u'\u4e2d\u56fd\u94f6\u884c\u7f51\u94f6\u52a9\u624b.dll'

--- a/windows/injection.py
+++ b/windows/injection.py
@@ -40,6 +40,14 @@ def perform_manual_getproc_loadlib_32(target, dll_name):
     code += x86.Call(":FUNC_GETPROCADDRESS32")
     code += x86.Push(x86.mem("[ECX + 8]"))
     code += x86.Call("EAX") # LoadLibrary
+    code += x86.Cmp("EAX", 0)
+    code += x86.Jnz(":end")
+    # GetLastError()
+    # I really don't want to resolve another function
+    # For a field that have been the same since XP/Win2003
+    code += x86.Mov('EAX', x86.mem('fs:[0x34]'))
+    code += x86.Add("EAX", 0x80000000)
+    code += x86.Label(":end")
     code += x86.Pop("ECX")
     code += x86.Pop("ECX")
     code += x86.Ret()
@@ -60,9 +68,18 @@ def perform_manual_getproc_loadlib_32(target, dll_name):
 
         t = target.execute(RemoteManualLoadLibray.get_code(), addr4)
         t.wait()
-        if not t.exit_code:
-            raise InjectionFailedError("Injection of <{0}> failed".format(dll_name))
-    return True
+        module_baseaddr = t.exit_code
+
+    if module_baseaddr & 0x80000000:
+        # Not a possible userland addr -> its a GetLastError()
+        error_code = module_baseaddr & 0x7fffffff
+        module_baseaddr = None
+        real_error = ctypes.WinError(error_code)
+        myexc = InjectionFailedError(u"Injection of <{0}> failed due to error <{1}> in injected process".format(dll_name, str(real_error)))
+        myexc.__cause__ = real_error
+        raise myexc
+
+    return module_baseaddr
 
 def perform_manual_getproc_loadlib_64(target, dll_name):
     dll = get_kernel32_dll_name()
@@ -76,18 +93,23 @@ def perform_manual_getproc_loadlib_64(target, dll_name):
     code += x64.Mov("RDX", x64.mem("[R15 + 8]"))
     code += x64.Call(":FUNC_GETPROCADDRESS64")
     code += x64.Mov("RCX", x64.mem("[R15 + 0x10]"))
-    code += x64.Push("RCX")
-    code += x64.Push("RCX")
-    code += x64.Push("RCX")
+    code += (x64.Push("RCX") * 3)
     code += x64.Call("RAX") # LoadLibrary
-    code += x64.Pop("RCX")
-    code += x64.Pop("RCX")
-    code += x64.Pop("RCX")
+    code += (x64.Pop("RCX") * 3)
+    code += x64.Mov("RCX", x64.mem("[R15]"))
+    code += x64.Mov(x64.mem("[RCX]"), "RAX")
+    # GetLastError()
+    # I really don't want to resolve another function
+    # For a field that have been the same since XP/Win2003
+    code += x64.Mov('RAX', x64.mem('gs:[0x68]'))
     code += x64.Ret()
 
     RemoteManualLoadLibray += GetProcAddress64
 
     with target.allocated_memory(0x1000) as addr:
+        # Addr contains the name of kernel32
+        # The data at addr are discadable after the call
+        # So, on return it contains the return PVOID64 value of LoadLibraryA
         addr2 = addr + len(dll)
         addr3 = addr2 + len(api)
         addr4 = addr3 + len(dll_to_load)
@@ -101,9 +123,15 @@ def perform_manual_getproc_loadlib_64(target, dll_name):
 
         t = target.execute(RemoteManualLoadLibray.get_code(), addr4)
         t.wait()
-        if not t.exit_code:
-            raise InjectionFailedError("Injection of <{0}> failed".format(dll_name))
-    return True
+        module_baseaddr = target.read_ptr(addr)
+        if not module_baseaddr:
+            module_baseaddr = None
+            real_error = ctypes.WinError(t.exit_code)
+            myexc = InjectionFailedError(u"Injection of <{0}> failed due to error <{1}> in injected process".format(dll_name, str(real_error)))
+            myexc.__cause__ = real_error
+            raise myexc
+
+    return module_baseaddr
 
 def generate_simple_LoadLibraryW_32_with_error(k32):
     """A shellcode that execute LoadLibraryW(param) and returns the value.


### PR DESCRIPTION
After discussing injections error with `MsStore python` (#72 #73). I have improved the error reporting when the injection fail with a `InjectionFailedError()`.

The new message contains the error code and error message of the `GetLastError()` in case of `LoadLibrary` fail.

Exemple:
```
OSError: [WinError 126] The specified module could not be found.

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "C:\Users\[XXX]\tstinjecterror.py", line 9, in <module>
    mod = p.load_library(r"C:\Users\[XXX]\NOFILE.dll")
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "c:\users\[XXX]\pythonforwindows\windows\winobject\process.py", line 1126, in load_library
    dllbase = windows.injection.load_dll_in_remote_process(self, dll_path)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "c:\users\[XXX]\pythonforwindows\windows\injection.py", line 236, in load_dll_in_remote_process
    raise myexc
windows.injection.InjectionFailedError: Injection of <C:\Users\[XXX]\NOFILE.dll> failed due to error <[WinError 126] The specified module could not be found.> in injected process
```

Return value of injection code on suspended process have also been fixed. (`perform_manual_getproc_loadlib_X`).
`True` was only returned when the module address was expected.

Related tests have been added.