### PR TITLE
Improve tests stability + new PEB_LDR_DATA definition

### DIFF
--- a/ctypes_generation/definitions/structures/winstruct.txt
+++ b/ctypes_generation/definitions/structures/winstruct.txt
@@ -4,11 +4,18 @@ typedef struct _LIST_ENTRY {
 } LIST_ENTRY, *PLIST_ENTRY, *RESTRICTED_POINTER PRLIST_ENTRY;
 
 
+/* Definition of WinXP : Still same base in win11 with some extra field */
 typedef struct _PEB_LDR_DATA {
-  BYTE       Reserved1[8];
-  PVOID      Reserved2[3];
-  LIST_ENTRY InMemoryOrderModuleList;
-} PEB_LDR_DATA, *PPEB_LDR_DATA;
+    ULONG               Length;
+    BYTE                Initialized;
+    PVOID               SsHandle;
+    _LIST_ENTRY         InLoadOrderModuleList;
+    _LIST_ENTRY         InMemoryOrderModuleList;
+    _LIST_ENTRY         InInitializationOrderModuleList;
+    PVOID               EntryInProgress;
+    // BYTE                ShutdownInProgress; // New field
+    // PVOID               ShutdownThreadId;   // New field
+}PEB_LDR_DATA, *PPEB_LDR_DATA;
 
 
 typedef struct _LSA_UNICODE_STRING {

--- a/docs/source/winstructs_generated.rst
+++ b/docs/source/winstructs_generated.rst
@@ -10521,19 +10521,39 @@ _PEB_LDR_DATA
 
 .. class:: _PEB_LDR_DATA
 
-    .. attribute:: Reserved1
+    .. attribute:: Length
 
-        :class:`BYTE` ``[8]``
+        :class:`ULONG`
 
 
-    .. attribute:: Reserved2
+    .. attribute:: Initialized
 
-        :class:`PVOID` ``[3]``
+        :class:`BYTE`
+
+
+    .. attribute:: SsHandle
+
+        :class:`PVOID`
+
+
+    .. attribute:: InLoadOrderModuleList
+
+        :class:`_LIST_ENTRY`
 
 
     .. attribute:: InMemoryOrderModuleList
 
-        :class:`LIST_ENTRY`
+        :class:`_LIST_ENTRY`
+
+
+    .. attribute:: InInitializationOrderModuleList
+
+        :class:`_LIST_ENTRY`
+
+
+    .. attribute:: EntryInProgress
+
+        :class:`PVOID`
 
 _LSA_UNICODE_STRING
 '''''''''''''''''''

--- a/tests/test_debugger.py
+++ b/tests/test_debugger.py
@@ -380,7 +380,7 @@ def test_standard_breakpoint_self_remove(proc32_64_debug, bptype):
     def do_check():
         time.sleep(1)
         try:
-            assert proc32_64_debug.peb.Ldr[0].Initialized, "peb.Ldr not yet Initialized"
+            assert proc32_64_debug.peb.Ldr.contents.Initialized, "peb.Ldr not yet Initialized"
             print("[==================] LOADING PYTHON")
             proc32_64_debug.execute_python_unsafe("1").wait()
             print("[==================] OPEN SELF_FILENAME1")
@@ -442,7 +442,7 @@ def test_standard_breakpoint_remove(proc32_64_debug, bptype):
     def do_check():
         time.sleep(1)
         try:
-            assert proc32_64_debug.peb.Ldr[0].Initialized, "peb.Ldr not yet Initialized"
+            assert proc32_64_debug.peb.Ldr.contents.Initialized, "peb.Ldr not yet Initialized"
             print("[==================] LOADING PYTHON")
             assert list(d.breakpoints.values())[0]
             proc32_64_debug.execute_python_unsafe("1").wait()

--- a/tests/test_debugger.py
+++ b/tests/test_debugger.py
@@ -440,7 +440,7 @@ def test_standard_breakpoint_remove(proc32_64_debug, bptype):
     data = set()
     thread_exception = []
     def do_check():
-        time.sleep(1)
+        time.sleep(2)
         try:
             assert proc32_64_debug.peb.Ldr.contents.Initialized, "peb.Ldr not yet Initialized"
             print("[==================] LOADING PYTHON")

--- a/windows/generated_def/winstructs.py
+++ b/windows/generated_def/winstructs.py
@@ -5438,9 +5438,13 @@ _LIST_ENTRY._fields_ = [
 
 class _PEB_LDR_DATA(Structure):
     _fields_ = [
-        ("Reserved1", BYTE * (8)),
-        ("Reserved2", PVOID * (3)),
-        ("InMemoryOrderModuleList", LIST_ENTRY),
+        ("Length", ULONG),
+        ("Initialized", BYTE),
+        ("SsHandle", PVOID),
+        ("InLoadOrderModuleList", _LIST_ENTRY),
+        ("InMemoryOrderModuleList", _LIST_ENTRY),
+        ("InInitializationOrderModuleList", _LIST_ENTRY),
+        ("EntryInProgress", PVOID),
     ]
 PEB_LDR_DATA = _PEB_LDR_DATA
 PPEB_LDR_DATA = POINTER(_PEB_LDR_DATA)


### PR DESCRIPTION
There is a non-documented part of `PEB_LDR_DATA` that did not change since WinXp.
It (among other things) contains `Initialized`. I updated the `ctypes_definition` with this one.