### PR TITLE
Add tests for NdrCString & NdrWString packing

### DIFF
--- a/tests/test_apisetmap.py
+++ b/tests/test_apisetmap.py
@@ -32,6 +32,8 @@ def verify_apisetmap_parsing(apisetmap_base, version=None):
     # Verify that at least one entry resolve to kernel32.dll
     # This ensure that the ApiSetMap parsing works at least a little
     assert "kernel32.dll" in apisetmap_dict.values()
+    for dll in sorted(apisetmap_dict):
+        print(dll)
     assert all(any(dll.startswith(pref) for pref in KNOWN_APISETMAP_PREFIX) for dll in apisetmap_dict)
     # This first key was found in most of the tested version by hand
     # MS-Win found on: 6.1.7600 (Win7)

--- a/tests/test_apisetmap.py
+++ b/tests/test_apisetmap.py
@@ -32,8 +32,11 @@ def verify_apisetmap_parsing(apisetmap_base, version=None):
     # Verify that at least one entry resolve to kernel32.dll
     # This ensure that the ApiSetMap parsing works at least a little
     assert "kernel32.dll" in apisetmap_dict.values()
+    print("Listing APISETMAP dlls")
     for dll in sorted(apisetmap_dict):
         print(dll)
+        if not any(dll.startswith(pref) for pref in KNOWN_APISETMAP_PREFIX):
+            print("Dll <dll> has unknown prefix".format(dll=dll))
     assert all(any(dll.startswith(pref) for pref in KNOWN_APISETMAP_PREFIX) for dll in apisetmap_dict)
     # This first key was found in most of the tested version by hand
     # MS-Win found on: 6.1.7600 (Win7)

--- a/tests/test_apisetmap.py
+++ b/tests/test_apisetmap.py
@@ -20,7 +20,7 @@ def dumped_apisetmap_base_and_version(request):
     ctypes_data = ctypes.c_buffer(data)
     yield ctypes.addressof(ctypes_data), version
 
-KNOWN_APISETMAP_PREFIX = ["api-", "ext-", "MS-Win-"]
+KNOWN_APISETMAP_PREFIX = ["api-", "ext-", "MS-Win-", "SchemaExt-"]
 
 def verify_apisetmap_parsing(apisetmap_base, version=None):
     if version is not None:
@@ -32,11 +32,6 @@ def verify_apisetmap_parsing(apisetmap_base, version=None):
     # Verify that at least one entry resolve to kernel32.dll
     # This ensure that the ApiSetMap parsing works at least a little
     assert "kernel32.dll" in apisetmap_dict.values()
-    print("Listing APISETMAP dlls")
-    for dll in sorted(apisetmap_dict):
-        print(dll)
-        if not any(dll.startswith(pref) for pref in KNOWN_APISETMAP_PREFIX):
-            print("Dll <dll> has unknown prefix".format(dll=dll))
     assert all(any(dll.startswith(pref) for pref in KNOWN_APISETMAP_PREFIX) for dll in apisetmap_dict)
     # This first key was found in most of the tested version by hand
     # MS-Win found on: 6.1.7600 (Win7)

--- a/tests/test_ndr.py
+++ b/tests/test_ndr.py
@@ -58,6 +58,11 @@ target = "APPP\x01\x02\x03\x04\x05\x06\x07\x08\x44PPP\x09\x0a\x0b\x0c\x0d\x0e\x0
 NDR_PACK_TEST_CASE = [
     # Simple case
     (ndr.make_structure([ndr.NdrLong, ndr.NdrLong]), (2, 2), b"\x02\x00\x00\x00\x02\x00\x00\x00"),
+    # String case, test packing works + \x00 is added if not present in string
+    (ndr.NdrCString, "Hello", b"\x06\x00\x00\x00\x00\x00\x00\x00\x06\x00\x00\x00Hello\x00PP"),
+    (ndr.NdrCString, "Hello\x00", b"\x06\x00\x00\x00\x00\x00\x00\x00\x06\x00\x00\x00Hello\x00PP"),
+    (ndr.NdrWString, "Hello", b"\x06\x00\x00\x00\x00\x00\x00\x00\x06\x00\x00\x00H\x00e\x00l\x00l\x00o\x00\x00\x00"),
+    (ndr.NdrWString, "Hello\x00", b"\x06\x00\x00\x00\x00\x00\x00\x00\x06\x00\x00\x00H\x00e\x00l\x00l\x00o\x00\x00\x00"),
     # Test GUID packing
     (ndr.NdrGuid, gdef.GUID.from_string("42424242-42424242-4242-4242-424242424242"), b"BBBBBBBBBBBBBBBB"),
     # Test CtxHandle packing

--- a/windows/rpc/ndr.py
+++ b/windows/rpc/ndr.py
@@ -160,6 +160,9 @@ class NdrWString(object):
             return None
         if not data.endswith('\x00'):
             data += '\x00'
+        # Technically windows NDR seems to accept any bitstream that ends with '\x00\x00' here
+        # And not limited to valid utf-16
+        # Exemple: b'\x41\x00\x00\xD8'
         data = data.encode("utf-16-le")
         l = (len(data) // 2)
         result = struct.pack("<3I", l, 0, l)
@@ -179,7 +182,7 @@ class NdrWString(object):
 
     @classmethod
     def get_alignment(self):
-        # Not sur, but size is on 4 bytes so...
+        # Not sure, but size is on 4 bytes so...
         return 4
 
 class NdrCString(object):
@@ -190,6 +193,10 @@ class NdrCString(object):
             return None
         if not data.endswith('\x00'):
             data += '\x00'
+        # Windows NDR seems to accept any bitstream in a FC_C_CSTRING
+        # I was able to send range(1, 256) + b"\x00"
+        # For now play safe for user and only accept encoded with always keep the same number of bytes
+        data = data.encode("ascii")
         l = len(data)
         result = struct.pack("<3I", l, 0, l)
         result += data


### PR DESCRIPTION
Fix #84 

Windows does seems to accept any bitstream that ends with `\x00` for an `FC_C_CSTRING`.
But for now, `NdrCString` use ascii encoding to be sure that encoding keep the same number of bytes that the input string.

I could also accept bytes() (and would apply no modification) to allow the user to send whatever it wants.
Same for `NdrWString`

#84 also made me realize there was no test for `NdrCString` & `NdrWString` packing. I added some.